### PR TITLE
Expose server modules at require('webgme-engine')

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,7 +193,7 @@ Object.defineProperties(exports, {
     AuthorizerBase: {
         get: function () {
             if (!_AuthorizerBase) {
-                _AuthorizerBase = require('./src/server/auth/middleware/authorizerbase');
+                _AuthorizerBase = require('./src/server/middleware/auth/authorizerbase');
             }
 
             return _AuthorizerBase;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ var requirejs = require('requirejs'),
     _Logger,
     _REGEXP,
     _PluginCliManager,
+    _WorkerManagerBase,
+    _AuthorizerBase,
+    _ServerWorkerManager,
     exports = {
         requirejs: requirejs
     };
@@ -108,7 +111,7 @@ function addToRequireJsPaths(gmeConfig) {
                 }
             } else {
                 throw new Error('Given requirejsPaths value is not a string nor array "' + keys[i] + '": ' +
-                '"' + requireJsPaths[keys[i]] + '"');
+                    '"' + requireJsPaths[keys[i]] + '"');
             }
         }
 
@@ -167,6 +170,33 @@ Object.defineProperties(exports, {
             }
 
             return _PluginCliManager;
+        }
+    },
+    WorkerManagerBase: {
+        get: function () {
+            if (!_WorkerManagerBase) {
+                _WorkerManagerBase = require('./src/server/worker/WorkerManagerBase');
+            }
+
+            return _WorkerManagerBase;
+        }
+    },
+    ServerWorkerManager: {
+        get: function () {
+            if (!_ServerWorkerManager) {
+                _ServerWorkerManager = require('./src/server/worker/serverworkermanager');
+            }
+
+            return _ServerWorkerManager;
+        }
+    },
+    AuthorizerBase: {
+        get: function () {
+            if (!_AuthorizerBase) {
+                _AuthorizerBase = require('./src/server/auth/middleware/authorizerbase');
+            }
+
+            return _AuthorizerBase;
         }
     }
 });

--- a/test/server/webgme.spec.js
+++ b/test/server/webgme.spec.js
@@ -24,6 +24,10 @@ describe('webgme', function () {
         expect(webGME).to.have.property('core');
         expect(webGME).to.have.property('Logger');
         expect(webGME).to.have.property('REGEXP');
+
+        expect(typeof webGME.WorkerManagerBase.prototype.request).to.equal('function');
+        expect(typeof webGME.ServerWorkerManager).to.equal('function');
+        expect(typeof webGME.AuthorizerBase.prototype.getAccessRights).to.equal('function');
     });
 
     it('should addToRequireJsPaths', function () {


### PR DESCRIPTION
These in turn will be propagated at `require('webgme')` and there is no need to find the correct path of modules nor any need to add webgme-engine as an explicit node_module to an app.