### PR TITLE
Use Node 8 and 6 for CI tests and make appropriate changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 
 node_modules
 
+#
+package-lock.json
+
 *.log
 .idea
 .vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ cache:
 #   depth: 5
 
 node_js:
-  - "4"
   - "6"
+  - "8"
 
 env:
   - TEST_BROWSER=true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Webgme-Engine
 This is the "engine" of the webgme app containing all server code, common-modules and client-api. 
-The webgme-engine was forked off from webgme/webgme at [version v2.17.0](https://github.com/webgme/webgme/releases/tag/v2.17.0) and since then is released separately from webgme starting off from v2.18.0 (note that all previous webgme code and tags still exist in this repo).
+The webgme-engine was forked off from webgme/webgme at [version v2.17.0](https://github.com/webgme/webgme/releases/tag/v2.17.0) and since then is released separately from webgme starting off from v2.18.0.
 
 Most documentation in the [webgme/webgme - wiki](https://github.com/webgme/webgme/wiki) is still applicable for this repository (all except the GUI specifics).
+
+[webgme/webgme](https://github.com/webgme/webgme) uses the engine as a dependency and a repository should only depend on
+one of these libraries.
 
 # Command line interface
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 
 environment:
   matrix:
-  - nodejs_version: "6"
+  - nodejs_version: "8"
     platform: x64
   # - nodejs_version: "4.2"
   #   platform: x86

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node ./src/bin/start_server.js",
-    "prepublish": "node ./utils/prepublish.js",
+    "prepublishOnly": "node ./utils/prepublish.js",
     "postinstall": "node ./utils/postinstall.js",
     "test": "node ./node_modules/mocha/bin/mocha --recursive test",
     "test_ci": "node ./node_modules/mocha/bin/mocha -R dot --timeout 10000 --recursive test",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "debug": "2.6.8",
     "express": "4.15.2",
     "ink-docstrap": "1.3.0",
-    "jsdoc": "3.4.3",
+    "jsdoc": "3.5.5",
     "jsonwebtoken": "7.4.1",
     "jszip": "2.5.0",
     "method-override": "2.3.8",

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -380,7 +380,7 @@ define([
      * @param {string} [message.severity='info'] - Severity level ('success', 'info', 'warn', 'error')
      * @param {boolean} [message.toBranch=false] - If true, and the plugin is running on the server on a branch -
      * will broadcast to all sockets in the branch room.
-     * @param {string} [callback] - optional callback invoked when message has been emitted from server.
+     * @param {function(Error)} [callback] - optional callback invoked when message has been emitted from server.
      */
     PluginBase.prototype.sendNotification = function (message, callback) {
         var self = this,
@@ -428,7 +428,7 @@ define([
      * To report the commits in the PluginResult make sure to invoke this.addCommitToResult with the given status.
      *
      * @param {string|null} message - commit message
-     * @param {function(Error|string, module:Storage~commitResult)} callback
+     * @param {function(Error, module:Storage~commitResult)} callback
      */
     PluginBase.prototype.save = function (message, callback) {
         var self = this,
@@ -533,7 +533,7 @@ define([
      * previous commit. Additionally if the namespaces have changed between commits - the this.META might end up
      * being empty.
      *
-     * @param {[function(Error, boolean)]} callback - Resolved with true if branch had moved forward.
+     * @param {function(Error, boolean)} [callback] - Resolved with true if branch had moved forward.
      * @returns {Promise}
      */
     PluginBase.prototype.fastForward = function (callback) {

--- a/test/addon/connectedworker.spec.js
+++ b/test/addon/connectedworker.spec.js
@@ -115,7 +115,7 @@ describe('Connected worker', function () {
             modulesToUnload = [];
 
         for (key in require.cache) {
-            if (require.cache.hasOwnProperty(key)) {
+            if (require.cache[key]) {
                 if (key.indexOf('connectedworker.js') > -1) {
                     modulesToUnload.push(key);
                 }

--- a/test/server/worker/simpleworker.spec.js
+++ b/test/server/worker/simpleworker.spec.js
@@ -274,7 +274,7 @@ describe('Simple worker', function () {
             modulesToUnload = [];
 
         for (key in require.cache) {
-            if (require.cache.hasOwnProperty(key)) {
+            if (require.cache[key]) {
                 if (key.indexOf('simpleworker.js') > -1) {
                     modulesToUnload.push(key);
                 }

--- a/utils/prepublish.js
+++ b/utils/prepublish.js
@@ -46,8 +46,16 @@ function prepublish(jsdocConfigPath) {
         console.log('Generating webgme source code documentation ...');
         childProcess.execFile(process.execPath, [
             path.join(__dirname, './jsdoc_build.js'),
-            '-c', jsdocConfigPath || './jsdoc_conf.json']);
-        console.log('Done with source code documentation!');
+            '-c', jsdocConfigPath || './jsdoc_conf.json'],
+            null,
+            function (err) {
+                if (err) {
+                    console.error('Failed generating source code documentation!', err);
+                    process.exit(1);
+                } else {
+                    console.log('Done with source code documentation!');
+                }
+            });
     }
 }
 


### PR DESCRIPTION
Note that webgme-engine should be released using node 8 as `prepublish` is deprecated and changed to `prepublishOnly`.