### PR TITLE
Track opened transactions and allow multiple invocations to join a single transaction

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -777,7 +777,7 @@ define([
                 state.rootHash = null;
                 //state.rootObject = null;
                 state.transactions.opened = 0;
-                state.transactions.callbackes = [];
+                state.transactions.callbacks = [];
                 state.msg = '';
 
                 cleanUsersTerritories();

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -1792,7 +1792,14 @@ define([
 
         this.completeTransaction = function (msg, callback) {
             state.transactions.opened -= 1;
-            ASSERT(state.transactions.opened < 0, 'More calls to completeTransaction than transactions started!');
+            if (callback) {
+                state.transactions.callbacks.push(callback);
+            }
+
+            if (state.transactions.opened < 0) {
+                state.transactions.opened = 0;
+                logger.error(new Error('More calls to completeTransaction than transactions started!'));
+            }
 
             if (state.core) {
                 msg = msg || ']';

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -71,7 +71,10 @@ define([
 
                 undoRedoChain: null, //{commitHash: '#hash', rootHash: '#hash', previous: object, next: object}
 
-                openedTransactions: 0,
+                transactions: {
+                    opened: 0,
+                    callbacks: []
+                },
                 msg: '',
                 gHash: 0,
                 loadError: null,
@@ -618,39 +621,35 @@ define([
             var persisted,
                 numberOfPersistedObjects,
                 wrappedCallback,
+                callbacks,
                 newCommitObject;
 
             logger.debug('saveRoot msg', msg);
-            if (callback) {
-                wrappedCallback = function (err, result) {
-                    if (err) {
-                        logger.error('saveRoot failure', err);
-                    } else {
-                        logger.debug('saveRoot', result);
-                    }
-                    callback(err, result);
-                };
-            } else {
-                wrappedCallback = function (err, result) {
-                    if (err) {
-                        logger.error('saveRoot failure', err);
-                    } else {
-                        logger.debug('saveRoot', result);
-                    }
-                };
-            }
 
             if (!state.viewer && !state.readOnlyProject && state.nodes[ROOT_PATH]) {
-                if (state.msg) {
-                    if (msg) {
-                        state.msg += '\n' + msg;
-                    }
+                if (state.msg && msg) {
+                    state.msg += '\n' + msg;
                 } else {
                     state.msg = msg;
                 }
 
-                if (state.openedTransactions === 0) {
+                if (state.transactions.opened === 0) {
                     ASSERT(state.project && state.core && state.branchName);
+
+                    callbacks = state.transactions.callbacks;
+                    state.transactions.callbacks = [];
+
+                    wrappedCallback = function (err, result) {
+                        if (err) {
+                            logger.error('saveRoot failure', err);
+                        } else {
+                            logger.debug('saveRoot', result);
+                        }
+
+                        callbacks.forEach(function (cb) {
+                            cb(err, result);
+                        });
+                    };
 
                     logger.debug('is NOT in transaction - will persist.');
                     // console.time('persist');
@@ -681,11 +680,12 @@ define([
                     state.msg = '';
                 } else {
                     logger.debug('is in transaction - will NOT persist.');
+
                 }
             } else {
                 //TODO: Why is this set to empty here?
                 state.msg = '';
-                wrappedCallback(null);
+                callback && callback(null);
             }
         }
 
@@ -776,7 +776,8 @@ define([
                 state.loadError = 0;
                 state.rootHash = null;
                 //state.rootObject = null;
-                state.openedTransactions = 0;
+                state.transactions.opened = 0;
+                state.transactions.callbackes = [];
                 state.msg = '';
 
                 cleanUsersTerritories();
@@ -1098,7 +1099,7 @@ define([
                 logger.debug('hashUpdateHandler invoked. project, branch, commitHash',
                     commitData.projectId, commitData.branchName, commitHash);
 
-                if (state.openedTransactions > 0) {
+                if (state.transactions.opened > 0) {
                     logger.warn('Is in transaction, will not load in changes');
                     callback(null, false); // proceed: false
                     return;
@@ -1781,7 +1782,7 @@ define([
 
         this.startTransaction = function (msg) {
             if (state.core) {
-                state.openedTransactions += 1;
+                state.transactions.opened += 1;
                 msg = typeof msg === 'string' ? msg : '[';
                 saveRoot(msg);
             } else {
@@ -1790,9 +1791,8 @@ define([
         };
 
         this.completeTransaction = function (msg, callback) {
-            state.openedTransactions -= 1;
-            // TODO: Maybe we should simply log this an error and reset it to 0..
-            ASSERT(state.openedTransactions > -1, 'More calls to completeTransaction than transactions started!');
+            state.transactions.opened -= 1;
+            ASSERT(state.transactions.opened < 0, 'More calls to completeTransaction than transactions started!');
 
             if (state.core) {
                 msg = msg || ']';

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -2629,6 +2629,7 @@ describe('GME client', function () {
 
             buildUpForTest(testId, {}, branchStatusHandler, function () {
                 client.removeUI(testId);//we do not need a UI and it would just make test code more complex
+                client.startTransaction('hello');
                 client.completeTransaction('should not persist anything', function (err) {
                     expect(err).to.equal(null);
                     expect(baseCommitHash).to.equal(client.getActiveCommitHash());

--- a/test-karma/client/js/client.spec.js
+++ b/test-karma/client/js/client.spec.js
@@ -2638,55 +2638,168 @@ describe('GME client', function () {
             });
         });
 
-        // FIXME: This throw an error.
-        it.skip('should start a transaction', function (done) {
+        it('should start a transaction', function (done) {
             var testId = 'basicStartTransaction',
                 testState = 'init',
-                commitHandler = function (queue, result, callback) {
-                    callback(false);
-                    done();
-                },
                 node = null;
 
             currentTestId = testId;
 
-            buildUpForTest(testId, {'/1': {children: 0}}, commitHandler, function (events) {
-                if (testState === 'init') {
-                    testState = 'checking';
+            buildUpForTest(testId, {'/1': {children: 0}}, null, function (events) {
+                try {
+                    if (testState === 'init') {
+                        testState = 'checking';
 
-                    expect(events).to.have.length(2);
-                    expect(events).to.deep.include({eid: '/1', etype: 'load'});
+                        expect(events).to.have.length(2);
+                        expect(events).to.deep.include({eid: '/1', etype: 'load'});
 
-                    node = client.getNode('/1');
-                    expect(node).not.to.equal(null);
-                    expect(node.getAttributeNames()).to.deep.equal(['name']);
-                    expect(node.getAttribute('name')).to.equal('FCO');
+                        node = client.getNode('/1');
+                        expect(node).not.to.equal(null);
+                        expect(node.getAttributeNames()).to.deep.equal(['name']);
+                        expect(node.getAttribute('name')).to.equal('FCO');
 
-                    client.startTransaction('starting a transaction');
-                    client.setAttribute('/1', 'name', 'FCOmodified', 'change without commit');
-                    client.setAttribute('/1', 'newAttribute', 42, 'another change without commit');
-                    client.setRegistry('/1', 'position', {x: 50, y: 50});
-                    client.completeTransaction('now will the events get generated');
+                        client.startTransaction('starting a transaction');
+                        client.setAttribute('/1', 'name', 'FCOmodified', 'change without commit');
+                        client.setAttribute('/1', 'newAttribute', 42, 'another change without commit');
+                        client.setRegistry('/1', 'position', {x: 50, y: 50});
+                        client.completeTransaction('now the events will get generated');
+                    } else if (testState === 'checking') {
+                        testState = null;
+
+                        expect(events).to.have.length(2);
+                        expect(events).to.deep.include({eid: '/1', etype: 'update'}, JSON.stringify(events));
+
+                        node = client.getNode('/1');
+                        expect(node).not.to.equal(null);
+                        expect(node.getAttributeNames()).to.include('newAttribute');
+                        expect(node.getAttribute('name')).to.equal('FCOmodified');
+                        expect(node.getAttribute('newAttribute')).to.equal(42);
+                        expect(node.getRegistry('position')).to.deep.equal({x: 50, y: 50});
+
+                        done();
+                    } else {
+                        throw new Error('more than one set of events arrived during or after a transaction!');
+                    }
+                } catch (e) {
+                    done(e);
                 }
+            });
+        });
 
-                if (testState === 'checking') {
-                    testState = null;
+        it('should start multiple transactions and all should join into one', function (done) {
+            var testId = 'multiTrans',
+                testState = 'init',
+                attrs = ['name', 'newAttribute', 'someOtherNew'],
+                node = null,
+                cnt = 0,
+                error;
 
-                    expect(events).to.have.length(2);
-                    expect(events).to.deep.include({eid: '/1', etype: 'update'});
+            currentTestId = testId;
 
-                    node = client.getNode('/1');
-                    expect(node).not.to.equal(null);
-                    expect(node.getAttributeNames()).to.include('newAttribute');
-                    expect(node.getAttribute('name')).to.equal('FCOmodified');
-                    expect(node.getAttribute('newAttribute')).to.equal(42);
-                    expect(node.getRegistry('position')).to.deep.equal({x: 50, y: 50});
+            buildUpForTest(testId, {'/1': {children: 0}}, null, function (events) {
+                try {
+                    if (testState === 'init') {
+                        testState = 'checking';
 
-                    return;
+                        expect(events).to.have.length(2);
+                        expect(events).to.deep.include({eid: '/1', etype: 'load'});
+
+                        node = client.getNode('/1');
+                        expect(node).not.to.equal(null);
+                        expect(node.getAttributeNames()).to.deep.equal(['name']);
+                        expect(node.getAttribute('name')).to.equal('FCO');
+
+                        attrs.forEach(function (attr) {
+                            client.startTransaction('starting a transaction');
+                            client.setAttribute('/1', attr, attr + 'value', 'change without commit');
+                            setTimeout(function () {
+                                client.completeTransaction('complete ' + attr, function (err, status) {
+                                    error = error || err;
+                                    cnt += 1;
+                                    if (cnt === attrs.length) {
+                                        done(error);
+                                    }
+                                });
+                            });
+                        });
+                    } else if (testState === 'checking') {
+                        testState = null;
+                        expect(events).to.have.length(2);
+                        expect(events).to.deep.include({eid: '/1', etype: 'update'}, JSON.stringify(events));
+
+                        node = client.getNode('/1');
+                        expect(node).not.to.equal(null);
+                        attrs.forEach(function (attr) {
+                            expect(node.getAttribute(attr)).to.equal(attr + 'value');
+                        });
+
+                    } else {
+                        throw new Error('more than one set of events arrived during or after a transaction!');
+                    }
+                } catch (e) {
+                    done(e);
                 }
+            });
+        });
 
-                if (testState === null) {
-                    throw new Error('more than one set of events arrived during or after a transaction!');
+        it('should start three transactions and call callback when provided', function (done) {
+            var testId = 'multiTransCallbacks',
+                testState = 'init',
+                attrs = ['name', 'newAttribute', 'someOtherNew'],
+                node = null,
+                cnt = 0,
+                error;
+
+            currentTestId = testId;
+
+            buildUpForTest(testId, {'/1': {children: 0}}, null, function (events) {
+                try {
+                    if (testState === 'init') {
+                        testState = 'checking';
+
+                        expect(events).to.have.length(2);
+                        expect(events).to.deep.include({eid: '/1', etype: 'load'});
+
+                        node = client.getNode('/1');
+                        expect(node).not.to.equal(null);
+                        expect(node.getAttributeNames()).to.deep.equal(['name']);
+                        expect(node.getAttribute('name')).to.equal('FCO');
+
+                        attrs.forEach(function (attr, index) {
+                            client.startTransaction('starting a transaction');
+                            client.setAttribute('/1', attr, attr + 'value', 'change without commit');
+                            setTimeout(function () {
+                                var cb = function (err, status) {
+                                    error = error || err;
+                                    cnt += 1;
+                                    if (cnt === attrs.length - 1) {
+                                        done(error);
+                                    }
+                                };
+
+                                if (index === 0) {
+                                    client.completeTransaction('complete no cb');
+                                } else {
+                                    client.completeTransaction('complete ' + attr, cb);
+                                }
+                            });
+                        });
+                    } else if (testState === 'checking') {
+                        testState = null;
+                        expect(events).to.have.length(2);
+                        expect(events).to.deep.include({eid: '/1', etype: 'update'}, JSON.stringify(events));
+
+                        node = client.getNode('/1');
+                        expect(node).not.to.equal(null);
+                        attrs.forEach(function (attr) {
+                            expect(node.getAttribute(attr)).to.equal(attr + 'value');
+                        });
+
+                    } else {
+                        throw new Error('more than one set of events arrived during or after a transaction!');
+                    }
+                } catch (e) {
+                    done(e);
                 }
             });
         });


### PR DESCRIPTION
This enables multiple independent UI pieces to make automatic changes all together in a single transaction.

```javascript
client.openTransaction('I will allow others to join my transaction');
client.setAttribute('/1', 'name', 'New FCO Name');
setTimeout(function () {
// When everyone else closed their transaction the commit will be made,
// and once it's been handled by the server the callback will be called.
  client.completeTransaction('Now Im done', function (err, status) {
  // Check err and commit status: {status: 'SYNCED', hash: '<commitHash>'}
  });
});
```