### PR TITLE
Websocket error reporting and promises in storage

### DIFF
--- a/src/common/storage/socketio/websocket.js
+++ b/src/common/storage/socketio/websocket.js
@@ -8,8 +8,9 @@
 //
 define([
     'common/EventDispatcher',
-    'common/storage/constants'
-], function (EventDispatcher, CONSTANTS) {
+    'common/storage/constants',
+    'q'
+], function (EventDispatcher, CONSTANTS, Q) {
 
     'use strict';
 
@@ -35,6 +36,11 @@ define([
                     callback.apply(null, arguments);
                 }
             };
+        }
+
+        function emitWithToken(data, eventName) {
+            data.webgmeToken = ioClient.getToken();
+            return Q.ninvoke(self.socket, 'emit', eventName, data);
         }
 
         this.connect = function (networkHandler) {
@@ -196,141 +202,222 @@ define([
 
         // watcher functions
         this.watchDatabase = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('watchDatabase', data, wrapError(callback));
+            return emitWithToken(data, 'watchDatabase')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.watchProject = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('watchProject', data, wrapError(callback));
+            return emitWithToken(data, 'watchProject')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.watchBranch = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('watchBranch', data, wrapError(callback));
+            return emitWithToken(data, 'watchBranch')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         // model editing functions
         this.openProject = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('openProject', data, wrapError(callback));
+            return emitWithToken(data, 'openProject')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.closeProject = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('closeProject', data, wrapError(callback));
+            return emitWithToken(data, 'closeProject')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.openBranch = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('openBranch', data, wrapError(callback));
+            return emitWithToken(data, 'openBranch')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.closeBranch = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('closeBranch', data, wrapError(callback));
+            return emitWithToken(data, 'closeBranch')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.makeCommit = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('makeCommit', data, wrapError(callback));
+            return emitWithToken(data, 'makeCommit')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.loadObjects = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('loadObjects', data, wrapError(callback));
+            return emitWithToken(data, 'loadObjects')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.loadPaths = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('loadPaths', data, wrapError(callback));
+            return emitWithToken(data, 'loadPaths')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.setBranchHash = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('setBranchHash', data, wrapError(callback));
+            return emitWithToken(data, 'setBranchHash')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.getBranchHash = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('getBranchHash', data, wrapError(callback));
+            return emitWithToken(data, 'getBranchHash')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.squashCommits = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('squashCommits', data, wrapError(callback));
+            return emitWithToken(data, 'squashCommits')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         // REST like functions
         this.getProjects = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('getProjects', data, wrapError(callback));
+            return emitWithToken(data, 'getProjects')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.deleteProject = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('deleteProject', data, wrapError(callback));
+            return emitWithToken(data, 'deleteProject')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.createProject = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('createProject', data, wrapError(callback));
+            return emitWithToken(data, 'createProject')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.transferProject = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('transferProject', data, wrapError(callback));
+            return emitWithToken(data, 'transferProject')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.duplicateProject = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('duplicateProject', data, wrapError(callback));
+            return emitWithToken(data, 'duplicateProject')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.getBranches = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('getBranches', data, wrapError(callback));
+            return emitWithToken(data, 'getBranches')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.createTag = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('createTag', data, wrapError(callback));
+            return emitWithToken(data, 'createTag')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.deleteTag = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('deleteTag', data, wrapError(callback));
+            return emitWithToken(data, 'deleteTag')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.getTags = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('getTags', data, wrapError(callback));
+            return emitWithToken(data, 'getTags')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.getCommits = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('getCommits', data, wrapError(callback));
+            return emitWithToken(data, 'getCommits')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.getHistory = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('getHistory', data, wrapError(callback));
+            return emitWithToken(data, 'getHistory')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.getLatestCommitData = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('getLatestCommitData', data, wrapError(callback));
+            return emitWithToken(data, 'getLatestCommitData')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.getCommonAncestorCommit = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('getCommonAncestorCommit', data, wrapError(callback));
+            return emitWithToken(data, 'getCommonAncestorCommit')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         //temporary simple request / result functions
         this.simpleRequest = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('simpleRequest', data, wrapError(callback));
+            return emitWithToken(data, 'simpleRequest')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.simpleQuery = function (workerId, data, callback) {
@@ -339,24 +426,36 @@ define([
         };
 
         this.sendNotification = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('notification', data, wrapError(callback));
+            return emitWithToken(data, 'notification')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         // OT handling
         this.watchDocument = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit('watchDocument', data, wrapError(callback));
+            return emitWithToken(data, 'watchDocument')
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         this.sendDocumentOperation = function (data, callback) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit(CONSTANTS.DOCUMENT_OPERATION, data, wrapError(callback));
+            return emitWithToken(data, CONSTANTS.DOCUMENT_OPERATION)
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
-        this.sendDocumentSelection = function (data) {
-            data.webgmeToken = ioClient.getToken();
-            self.socket.emit(CONSTANTS.DOCUMENT_SELECTION, data);
+        this.sendDocumentSelection = function (data, callback) {
+            return emitWithToken(data, CONSTANTS.DOCUMENT_SELECTION)
+                .catch(function (err) {
+                    return Q.reject(new Error(err));
+                })
+                .nodeify(callback);
         };
 
         // Helper functions

--- a/src/common/storage/socketio/websocket.js
+++ b/src/common/storage/socketio/websocket.js
@@ -29,6 +29,7 @@ define([
         EventDispatcher.call(this);
 
         function emitWithToken(data, eventName, callback) {
+            logger.debug('emitting event', eventName, {metadata: data});
             data.webgmeToken = ioClient.getToken();
             if (callback) {
                 self.socket.emit(eventName, data, callback);

--- a/src/common/storage/storageclasses/simpleapi.js
+++ b/src/common/storage/storageclasses/simpleapi.js
@@ -34,7 +34,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
 
     StorageSimpleAPI.prototype.getProjects = function (options, callback) {
         this.logger.debug('invoking getProjects', {metadata: options});
-        this.webSocket.getProjects(options, callback);
+        return this.webSocket.getProjects(options).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.getProjectInfo = function (projectId, callback) {
@@ -47,13 +47,11 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
         };
 
         this.logger.debug('invoking getProjectInfo', {metadata: data});
-        this.webSocket.getProjects(data, function (err, result) {
-            if (err) {
-                callback(err);
-            } else {
-                callback(null, result[0]);
-            }
-        });
+        return this.webSocket.getProjects(data)
+            .then(function (result) {
+                return result[0];
+            })
+            .nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.getBranches = function (projectId, callback) {
@@ -61,7 +59,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             projectId: projectId
         };
         this.logger.debug('invoking getBranches', {metadata: data});
-        this.webSocket.getBranches(data, callback);
+        return this.webSocket.getBranches(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.getCommits = function (projectId, before, number, callback) {
@@ -71,7 +69,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             number: number
         };
         this.logger.debug('invoking getCommits', {metadata: data});
-        this.webSocket.getCommits(data, callback);
+        return this.webSocket.getCommits(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.getHistory = function (projectId, start, number, callback) {
@@ -81,7 +79,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             number: number
         };
         this.logger.debug('invoking getHistory', {metadata: data});
-        this.webSocket.getHistory(data, callback);
+        return this.webSocket.getHistory(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.squashCommits = function (projectId, fromCommit, toCommitOrBranch, msg, callback) {
@@ -92,7 +90,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             message: msg
         };
         this.logger.debug('invoking squashCommits', {metadata: data});
-        this.webSocket.squashCommits(data, callback);
+        return this.webSocket.squashCommits(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.getTags = function (projectId, callback) {
@@ -100,7 +98,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             projectId: projectId
         };
         this.logger.debug('invoking getTags', {metadata: data});
-        this.webSocket.getTags(data, callback);
+        return this.webSocket.getTags(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.getBranchHash = function (projectId, branchName, callback) {
@@ -109,7 +107,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             branchName: branchName
         };
         this.logger.debug('invoking getBranchHash', {metadata: data});
-        this.webSocket.getBranchHash(data, callback);
+        return this.webSocket.getBranchHash(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.getLatestCommitData = function (projectId, branchName, callback) {
@@ -118,7 +116,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             branchName: branchName
         };
         this.logger.debug('invoking getLatestCommitData', {metadata: data});
-        this.webSocket.getLatestCommitData(data, callback);
+        return this.webSocket.getLatestCommitData(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.getCommonAncestorCommit = function (projectId, commitA, commitB, callback) {
@@ -128,15 +126,14 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             projectId: projectId
         };
         this.logger.debug('invoking getCommonAncestorCommit', {metadata: data});
-        this.webSocket.getCommonAncestorCommit(data, callback);
+        return this.webSocket.getCommonAncestorCommit(data).nodeify(callback);
     };
 
     // Setters
     StorageSimpleAPI.prototype.createProject = function (projectName, ownerId, kind, callback) {
-        var self = this,
-            data = {
-                projectName: projectName
-            };
+        var data = {
+            projectName: projectName
+        };
 
         if (callback === undefined) {
             if (typeof ownerId === 'function') {
@@ -152,16 +149,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
 
         this.logger.debug('invoking createProject', {metadata: data});
 
-        this.webSocket.createProject(data, function (err, projectId) {
-            if (err) {
-                self.logger.error('cannot create project ', projectName, err);
-                callback(err);
-                return;
-            }
-            self.logger.debug('Project created, projectId', projectId);
-
-            callback(err, projectId);
-        });
+        return this.webSocket.createProject(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.deleteProject = function (projectId, callback) {
@@ -169,7 +157,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             projectId: projectId
         };
         this.logger.debug('invoking deleteProject', {metadata: data});
-        this.webSocket.deleteProject(data, callback);
+        return this.webSocket.deleteProject(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.transferProject = function (projectId, newOwnerId, callback) {
@@ -178,7 +166,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             newOwnerId: newOwnerId
         };
         this.logger.debug('invoking transferProject', {metadata: data});
-        this.webSocket.transferProject(data, callback);
+        return this.webSocket.transferProject(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.duplicateProject = function (projectId, projectName, ownerId, callback) {
@@ -194,7 +182,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
         }
 
         this.logger.debug('invoking duplicateProject', {metadata: data});
-        this.webSocket.duplicateProject(data, callback);
+        return this.webSocket.duplicateProject(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.setBranchHash = function (projectId, branchName, newHash, oldHash, callback) {
@@ -204,8 +192,9 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             newHash: newHash,
             oldHash: oldHash
         };
+
         this.logger.debug('invoking setBranchHash', {metadata: data});
-        this.webSocket.setBranchHash(data, callback);
+        return this.webSocket.setBranchHash(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.createBranch = function (projectId, branchName, newHash, callback) {
@@ -215,8 +204,9 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             newHash: newHash,
             oldHash: ''
         };
+
         this.logger.debug('invoking createBranch', {metadata: data});
-        this.webSocket.setBranchHash(data, callback);
+        return this.webSocket.setBranchHash(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.deleteBranch = function (projectId, branchName, oldHash, callback) {
@@ -227,7 +217,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             oldHash: oldHash
         };
         this.logger.debug('invoking deleteBranch', {metadata: data});
-        this.webSocket.setBranchHash(data, callback);
+        return this.webSocket.setBranchHash(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.createTag = function (projectId, tagName, commitHash, callback) {
@@ -237,7 +227,7 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             commitHash: commitHash
         };
         this.logger.debug('invoking createTag', {metadata: data});
-        this.webSocket.createTag(data, callback);
+        return this.webSocket.createTag(data).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.deleteTag = function (projectId, tagName, callback) {
@@ -246,23 +236,23 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             tagName: tagName
         };
         this.logger.debug('invoking deleteTag', {metadata: data});
-        this.webSocket.deleteTag(data, callback);
+        return this.webSocket.deleteTag(data).nodeify(callback);
     };
 
     //temporary simple request and result functions
     StorageSimpleAPI.prototype.simpleRequest = function (parameters, callback) {
         this.logger.debug('invoking simpleRequest', {metadata: parameters});
-        this.webSocket.simpleRequest(parameters, callback);
+        return this.webSocket.simpleRequest(parameters).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.simpleQuery = function (workerId, parameters, callback) {
         this.logger.debug('invoking simpleQuery; workerId, parameters', workerId, {metadata: parameters});
-        this.webSocket.simpleQuery(workerId, parameters, callback);
+        return this.webSocket.simpleQuery(workerId, parameters).nodeify(callback);
     };
 
     StorageSimpleAPI.prototype.sendNotification = function (data, callback) {
         this.logger.debug('invoking sendNotification; ', {metadata: data});
-        this.webSocket.sendNotification(data, callback);
+        return this.webSocket.sendNotification(data).nodeify(callback);
     };
 
     return StorageSimpleAPI;

--- a/src/common/storage/storageclasses/watchers.js
+++ b/src/common/storage/storageclasses/watchers.js
@@ -166,6 +166,7 @@ define(['common/storage/constants', 'q', 'common/util/guid', 'webgme-ot'], funct
         this.watchers.documents[docId] = {
             eventHandler: function (_ws, eData) {
                 var otClient = self.watchers.documents[eData.docId].otClient;
+                self.logger.debug('eventHandler for document', {metadata: eData});
                 if (eData.operation) {
                     if (self.reconnecting) {
                         // We are reconnecting.. Put these on the queue.
@@ -249,7 +250,8 @@ define(['common/storage/constants', 'q', 'common/util/guid', 'webgme-ot'], funct
      * @returns {Promise}
      */
     StorageWatcher.prototype.unwatchDocument = function (data, callback) {
-        var deferred = Q.defer(),
+        var self = this,
+            deferred = Q.defer(),
             docUpdateEventName = this.webSocket.getDocumentUpdatedEventName(data),
             docSelectionEventName = this.webSocket.getDocumentSelectionEventName(data),
             pieces;
@@ -319,7 +321,8 @@ define(['common/storage/constants', 'q', 'common/util/guid', 'webgme-ot'], funct
      * @param {ot.Selection} data.selection
      */
     StorageWatcher.prototype.sendDocumentSelection = function (data) {
-        var otClient;
+        var self = this,
+            otClient;
         if (this.watchers.documents.hasOwnProperty(data.docId) &&
             this.watchers.documents[data.docId].otClient instanceof ot.Client) {
 
@@ -331,6 +334,10 @@ define(['common/storage/constants', 'q', 'common/util/guid', 'webgme-ot'], funct
                     docId: data.docId,
                     revision: otClient.revision,
                     selection: data.selection
+                }, function (err) {
+                    if (err) {
+                        self.logger.error(err);
+                    }
                 });
             }
 

--- a/src/common/storage/storageclasses/watchers.js
+++ b/src/common/storage/storageclasses/watchers.js
@@ -250,8 +250,7 @@ define(['common/storage/constants', 'q', 'common/util/guid', 'webgme-ot'], funct
      * @returns {Promise}
      */
     StorageWatcher.prototype.unwatchDocument = function (data, callback) {
-        var self = this,
-            deferred = Q.defer(),
+        var deferred = Q.defer(),
             docUpdateEventName = this.webSocket.getDocumentUpdatedEventName(data),
             docSelectionEventName = this.webSocket.getDocumentSelectionEventName(data),
             pieces;

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -331,6 +331,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, info);
                     })
                     .catch(function (err) {
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
                         callback(err.message);
                     });
             });
@@ -343,7 +344,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                 } else {
                     socket.leave(CONSTANTS.DATABASE_ROOM);
                 }
-                callback(null);
+
+                callback();
             });
 
             socket.on('watchProject', function (data, callback) {
@@ -355,7 +357,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                             if (access.read) {
                                 socket.join(data.projectId);
                                 logger.debug('socket joined room', data.projectId);
-                                callback(null);
+                                callback();
                             } else {
                                 logger.warn('socket not authorized to join room', data.projectId);
                                 callback('No read access for ' + data.projectId);
@@ -363,15 +365,12 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         } else {
                             socket.leave(data.projectId);
                             logger.debug('socket left room', data.projectId);
-                            callback(null);
+                            callback();
                         }
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -402,11 +401,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -436,11 +432,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, branches, access);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -457,11 +450,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback();
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -485,11 +475,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, latestCommitData);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -575,6 +562,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                     });
                                 })
                                 .catch(function (err) {
+                                    logger.error(err.stack, '\n', (new Error('Caught by')).stack);
                                     callback(err.message);
                                 });
                         } else {
@@ -582,11 +570,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         }
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -600,11 +585,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, loadedObjects); //Single load-fails are reported in this object.
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -618,11 +600,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, hashDictionary);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -653,11 +632,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, status);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -671,11 +647,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, result);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -690,11 +663,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, projects);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -712,11 +682,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, didExist);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -734,11 +701,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, project.projectId);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -756,11 +720,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, newProjectId);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -778,11 +739,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, newProject.projectId);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -797,11 +755,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, branches);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -815,11 +770,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -833,11 +785,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -851,11 +800,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, tags);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -869,11 +815,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, commits);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -887,11 +830,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, commits);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -905,11 +845,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, commitData);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -923,11 +860,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, commonCommitHash);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -941,11 +875,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null, commitResult);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -971,11 +902,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         });
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -1016,11 +944,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         callback(null);
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -1137,11 +1062,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         }
                     })
                     .catch(function (err) {
-                        if (gmeConfig.debug) {
-                            callback(err.stack);
-                        } else {
-                            callback(err.message);
-                        }
+                        logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                        callback(err.message);
                     });
             });
 
@@ -1170,11 +1092,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         throw new Error('Client not watching document - cannot send operation!');
                     }
                 } catch (err) {
-                    if (gmeConfig.debug) {
-                        callback(err.stack);
-                    } else {
-                        callback(err.message);
-                    }
+                    logger.error(err.stack, '\n', (new Error('Caught by')).stack);
+                    callback(err.message);
                 }
             });
 
@@ -1205,6 +1124,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                         throw new Error('Client not watching document - cannot send selection!');
                     }
                 } catch (err) {
+                    logger.error(err.stack, '\n', (new Error('Caught by')).stack);
                     done(err);
                 }
             });

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -1139,6 +1139,15 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             socketIds.forEach(function (socketId) {
                 webSocket.sockets.connected[socketId].disconnect();
             });
+            Object.keys(documents).forEach(function (docId) {
+                logger.warn('Document room was open - will close it', docId);
+
+                if (documents[docId].timeoutId) {
+                    clearTimeout(documents[docId].timeoutId);
+                }
+
+                delete documents[docId];
+            });
             webSocket = null;
         }
     };

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -812,4 +812,8 @@ exports.noop = function () {
 
 };
 
+exports.copy = function copy(obj) {
+    return JSON.parse(JSON.stringify(obj));
+};
+
 module.exports = exports;

--- a/test/common/storage/storageclasses/connection.spec.js
+++ b/test/common/storage/storageclasses/connection.spec.js
@@ -936,10 +936,11 @@ describe('storage-connection', function () {
                             storage2.open(function (networkState2) {
                                 if (networkState2 === STORAGE_CONSTANTS.CONNECTED) {
                                     Q.allDone([
-                                        storage.watchDocument(docData, function atOperation() {
+                                        storage.watchDocument(testFixture.copy(docData), function atOperation() {
                                             opHandlerCalled = true;
                                         }, testFixture.noop),
-                                        storage2.watchDocument(docData, testFixture.noop, testFixture.noop)
+                                        storage2.watchDocument(testFixture.copy(docData), testFixture.noop,
+                                            testFixture.noop)
                                     ])
                                         .then(function (result) {
                                             docId = result[0].docId;

--- a/test/common/storage/storageclasses/editorstorage.spec.js
+++ b/test/common/storage/storageclasses/editorstorage.spec.js
@@ -179,9 +179,9 @@ describe('storage storageclasses editorstorage', function () {
     }
 
     it('should closeBranch if it is not open', function (done) {
-        Q.nfcall(storage.openProject, projectName2Id(projectName))
+        storage.openProject(projectName2Id(projectName))
             .then(function () {
-                return Q.nfcall(storage.closeBranch, projectName2Id(projectName), 'not_open');
+                return storage.closeBranch(projectName2Id(projectName), 'not_open');
             })
             .nodeify(done);
     });
@@ -192,12 +192,12 @@ describe('storage storageclasses editorstorage', function () {
     });
 
     it('should open and close project', function (done) {
-        Q.nfcall(storage.openProject, projectName2Id(projectName))
+        storage.openProject(projectName2Id(projectName))
             .then(function () {
-                return Q.nfcall(storage.closeProject, projectName2Id(projectName));
+                return storage.closeProject(projectName2Id(projectName));
             })
             .then(function () {
-                return Q.nfcall(storage.closeProject, projectName2Id(projectName));
+                return storage.closeProject(projectName2Id(projectName));
             })
             .nodeify(done);
     });

--- a/test/common/storage/storageclasses/watchers_documents.spec.js
+++ b/test/common/storage/storageclasses/watchers_documents.spec.js
@@ -159,8 +159,8 @@ describe('storage document editing', function () {
                 user2 = res[1];
 
                 return Q.allDone([
-                    user1.watchDocument(initParams, noop, noop),
-                    user2.watchDocument(initParams,
+                    user1.watchDocument(testFixture.copy(initParams), noop, noop),
+                    user2.watchDocument(testFixture.copy(initParams),
                         function atOp2(op) {
                             try {
                                 expect(op.apply(initParams.attrValue)).to.equal('hello there');
@@ -210,8 +210,8 @@ describe('storage document editing', function () {
                 user2 = res[1];
 
                 return Q.allDone([
-                    user1.watchDocument(initParams, noop, noop),
-                    user2.watchDocument(initParams,
+                    user1.watchDocument(testFixture.copy(initParams), noop, noop),
+                    user2.watchDocument(testFixture.copy(initParams),
                         function atOp2(op) {
                             cnt += 1;
                             try {
@@ -269,8 +269,8 @@ describe('storage document editing', function () {
                 user2 = res[1];
 
                 return Q.allDone([
-                    user1.watchDocument(initParams, noop, noop),
-                    user2.watchDocument(initParams,
+                    user1.watchDocument(testFixture.copy(initParams), noop, noop),
+                    user2.watchDocument(testFixture.copy(initParams),
                         function atOp2(op) {
                             cnt += 1;
                             try {
@@ -333,7 +333,7 @@ describe('storage document editing', function () {
                 user2 = res[1];
 
                 return Q.allDone([
-                    user1.watchDocument(initParams,
+                    user1.watchDocument(testFixture.copy(initParams),
                         function atOp1(op) {
                             cnt += 1;
                             try {
@@ -346,7 +346,7 @@ describe('storage document editing', function () {
                             }
                         }, noop
                     ),
-                    user2.watchDocument(initParams,
+                    user2.watchDocument(testFixture.copy(initParams),
                         function atOp2(op) {
                             cnt += 1;
                             try {
@@ -403,8 +403,8 @@ describe('storage document editing', function () {
                 user2 = res[1];
 
                 return Q.allDone([
-                    user1.watchDocument(initParams, noop, noop),
-                    user2.watchDocument(initParams, noop,
+                    user1.watchDocument(testFixture.copy(initParams), noop, noop),
+                    user2.watchDocument(testFixture.copy(initParams), noop,
                         function atSel2(data) {
                             cnt += 1;
                             if (cnt > 1) {
@@ -463,7 +463,7 @@ describe('storage document editing', function () {
                 user2 = res[1];
 
                 return Q.allDone([
-                    user1.watchDocument(initParams,
+                    user1.watchDocument(testFixture.copy(initParams),
                         function atOp1(op) {
                             cnt += 1;
                             try {
@@ -476,7 +476,7 @@ describe('storage document editing', function () {
                             }
                         }, noop
                     ),
-                    user2.watchDocument(initParams, noop,
+                    user2.watchDocument(testFixture.copy(initParams), noop,
                         function atSel2(data) {
                             cnt += 1;
                             if (cnt > 2) {
@@ -535,7 +535,7 @@ describe('storage document editing', function () {
                 user2 = res[1];
 
                 return Q.allDone([
-                    user1.watchDocument(initParams, noop, function atSel2(data) {
+                    user1.watchDocument(testFixture.copy(initParams), noop, function atSel2(data) {
                         cnt += 1;
                         if (cnt > 2) {
                             return;
@@ -550,7 +550,7 @@ describe('storage document editing', function () {
                             done(e);
                         }
                     }),
-                    user2.watchDocument(initParams, noop, noop)
+                    user2.watchDocument(testFixture.copy(initParams), noop, noop)
                 ]);
             })
             .then(function (res) {
@@ -591,11 +591,11 @@ describe('storage document editing', function () {
                 userRead = res[1];
 
                 return Q.allDone([
-                    user1.watchDocument(initParams, function () {
+                    user1.watchDocument(testFixture.copy(initParams), function () {
                         clearTimeout(tId);
                         done(new Error('should not receive any operations'));
                     }, noop),
-                    userRead.watchDocument(initParams,
+                    userRead.watchDocument(testFixture.copy(initParams),
                         function atOp2(op) {
                             try {
                                 expect(op.apply(initParams.attrValue)).to.equal('hello there');
@@ -644,7 +644,7 @@ describe('storage document editing', function () {
             .then(function (res) {
                 userNoAccess = res;
 
-                return userNoAccess.watchDocument(initParams, noop, noop);
+                return userNoAccess.watchDocument(testFixture.copy(initParams), noop, noop);
             })
             .then(function (res) {
                 throw new Error('Should not succeed!');
@@ -735,11 +735,11 @@ describe('storage document editing', function () {
                 docId = storage.webSocket.getDocumentUpdatedEventName(initParams)
                     .substring(CONSTANTS.DOCUMENT_OPERATION.length);
 
-                return storage.watchDocument(initParams, noop, noop);
+                return storage.watchDocument(testFixture.copy(initParams), noop, noop);
             })
             .then(function (res) {
                 users['user1'].docId = res.docId;
-                return storage.watchDocument(initParams, noop, noop);
+                return storage.watchDocument(testFixture.copy(initParams), noop, noop);
             })
             .then(function (res) {
                 throw new Error('Should not succeed!');
@@ -767,7 +767,7 @@ describe('storage document editing', function () {
                 docId = storage.webSocket.getDocumentUpdatedEventName(initParams)
                     .substring(CONSTANTS.DOCUMENT_OPERATION.length);
 
-                return storage.unwatchDocument(initParams);
+                return storage.unwatchDocument(testFixture.copy(initParams));
             })
             .then(function (res) {
                 throw new Error('Should not succeed!');

--- a/test/common/storage/storageclasses/watchers_documents.spec.js
+++ b/test/common/storage/storageclasses/watchers_documents.spec.js
@@ -8,7 +8,7 @@
 
 var testFixture = require('../../../_globals.js');
 
-describe('storage document editing', function () {
+describe('watchers documents', function () {
     'use strict';
     var gmeConfig = testFixture.getGmeConfig(),
         CONSTANTS = testFixture.requirejs('common/storage/constants'),
@@ -84,7 +84,7 @@ describe('storage document editing', function () {
     });
 
     function getNewStorage(userId) {
-        return testFixture.getConnectedStorage(gmeConfig, logger, userTokens[userId])
+        return testFixture.getConnectedStorage(gmeConfig, logger.fork(userId), userTokens[userId])
             .then(function (storage) {
                 users[userId] = {
                     storage: storage,
@@ -381,7 +381,7 @@ describe('storage document editing', function () {
     });
 
     // Selections
-    it('should send selection when synchronized and it should be transformed for other client', function (done) {
+    it.only('should send selection when synchronized and it should be transformed for other client', function (done) {
         var user1,
             user2,
             docId,


### PR DESCRIPTION
Log errors i websocket request on server. Include the full stack of the error and the stack to where the error was caught (that way it's clear which request caused the error).

On the client side the wrapping of the error message now takes place inside the method in the storage - that way the error can be traced to the method causing it (rather than showing the stack of the internal socket.io call).

Simple APIs of the storage are all wrapped in promises. open/close/Project/Branch are also wrapped. However method dealing with makeCommit, setBranchHash and sending document operations are currently not wrapped.