### PR TITLE
Prohibit core and storage to bombard server with loadPaths requests

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -215,6 +215,7 @@ var path = require('path'),
 
         storage: {
             cache: 2000,
+            freezeCache: false,
             // If true events such as PROJECT_CREATED and BRANCH_CREATED will only be broadcasted
             // and not emitted back to the web-socket that triggered the event.
             broadcastProjectEvents: false,

--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -526,7 +526,7 @@ define([
 
             for (i = 0; i < relids.length; i++) {
                 done = TASYNC.call(subComputationFinished,
-                    fillMissingGuid(root, sRoot, path + '/' + relids[i], diff[relids[i]]), relids[i]);
+                    fillMissingGuid(root, sRoot, path + '/' + relids[i], diff[relids[i]]), relids[i], done);
             }
 
             return TASYNC.call(function () {
@@ -799,18 +799,18 @@ define([
                     //move
                     needChecking = true;
                     delete yetToCompute[guids[i]];
-                    done = TASYNC.call(computingMove, updateDiff(ytc.from, ytc.to, yetToCompute), ytc);
+                    done = TASYNC.call(computingMove, updateDiff(ytc.from, ytc.to, yetToCompute), ytc, done);
                 } else {
                     if (ytc.from && ytc.fromExpanded === false) {
                         //expand from
                         ytc.fromExpanded = true;
                         needChecking = true;
-                        done = TASYNC.call(expandFrom, expandDiff(ytc.from, true, yetToCompute), ytc);
+                        done = TASYNC.call(expandFrom, expandDiff(ytc.from, true, yetToCompute), ytc, done);
                     } else if (ytc.to && ytc.toExpanded === false) {
                         //expand to
                         ytc.toExpanded = true;
                         needChecking = true;
-                        done = TASYNC.call(expandTo, expandDiff(ytc.to, false, yetToCompute), ytc);
+                        done = TASYNC.call(expandTo, expandDiff(ytc.to, false, yetToCompute), ytc, done);
                     }
                 }
             }
@@ -1251,7 +1251,7 @@ define([
                 if (pointerDiff[keys[i]] === CONSTANTS.TO_DELETE_STRING) {
                     self.deletePointer(node, keys[i]);
                 } else if (diff.removed !== false || keys[i] !== 'base') {
-                    done = setPointer(node, keys[i], pointerDiff[keys[i]]);
+                    done = setPointer(node, keys[i], pointerDiff[keys[i]], done);
                 }
             }
 
@@ -1332,7 +1332,8 @@ define([
                             if (setDiff[setNames[i]][elements[j]] === CONSTANTS.TO_DELETE_STRING) {
                                 self.delMember(node, setNames[i], elements[j]);
                             } else {
-                                done = addMember(node, setNames[i], elements[j], setDiff[setNames[i]][elements[j]]);
+                                done = addMember(node, setNames[i], elements[j], setDiff[setNames[i]][elements[j]],
+                                    done);
                             }
                         }
                     }

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -69,6 +69,10 @@ define([
 
                 node.base = target;
 
+                if (!target) {
+                    logger.error('No target in loadBase2', target);
+                }
+
                 return node;
             }
         }
@@ -272,7 +276,7 @@ define([
         }
 
         function isValidNodeThrow(node) {
-            test('core', innerCore.isValidNode(node));
+            test('corerel', innerCore.isValidNode(node));
             test('base', typeof node.base === 'object');
         }
 

--- a/src/common/core/metacachecore.js
+++ b/src/common/core/metacachecore.js
@@ -60,12 +60,6 @@ define([
             }, innerCore.loadRoot(hash));
         };
 
-        this.loadByPath = function (node, path) {
-            return TASYNC.call(function () {
-                return innerCore.loadByPath(node, path);
-            }, self.loadPaths(self.getHash(node), [path]));
-        };
-
         //functions where the cache may needs to be updated
         this.createNode = function (parameters) {
             var node = innerCore.createNode(parameters);

--- a/src/common/storage/project/cache.js
+++ b/src/common/storage/project/cache.js
@@ -301,7 +301,7 @@ define([
                     });
 
                     // Finally clear out all entries stored for this id..
-                    delete ongoingPathsRequests[rootKey + paths[i]];
+                    delete ongoingPathsRequests[id];
                 }
 
                 if (!err && serverObjects) {

--- a/src/common/storage/project/cache.js
+++ b/src/common/storage/project/cache.js
@@ -123,7 +123,7 @@ define([
 
                                 if ((loadResult || {}).multipleObjects === true) {
                                     for (subKey in loadResult.objects) {
-                                        callbacks = ongoingObjectRequests[subKey];
+                                        callbacks = ongoingObjectRequests[subKey] || [];
                                         delete ongoingObjectRequests[subKey];
                                         if (!err && loadResult.objects[subKey]) {
                                             cacheInsert(subKey, loadResult.objects[subKey]);
@@ -136,7 +136,7 @@ define([
                                         }
                                     }
                                 } else {
-                                    callbacks = ongoingObjectRequests[key];
+                                    callbacks = ongoingObjectRequests[key] || [];
                                     delete ongoingObjectRequests[key];
                                     if (!err && loadResult) {
                                         cacheInsert(key, loadResult);

--- a/src/server/storage/storage.js
+++ b/src/server/storage/storage.js
@@ -530,9 +530,7 @@ Storage.prototype.loadPaths = function (data, callback) {
                     if (data.excludes) {
                         for (i = 0; i < keys.length; i += 1) {
                             if (data.excludes.indexOf(keys[i]) > -1) {
-                                // https://jsperf.com/delete-vs-setting-undefined-vs-new-object
-                                // When sending the data these keys will be removed after JSON.stringify.
-                                loadedObjects[keys[i]] = undefined;
+                                delete loadedObjects[keys[i]];
                             }
                         }
                     }


### PR DESCRIPTION
This issue lead to strange behaviors with large models where the server received thousands of loadPaths requests (mostly requesting the same objects).

The PR includes:
- Do not use loadPaths in core for single load requests.
- loadPaths in cache keeps track of all requested paths (w.r.t. the rootKey) and minimizes number of calls.
- Fixes some potential resolving of promises in corediff.
- Adds option to freeze objects in cache (used for debugging)
  