### PR TITLE
Fixes #41 introduce maxQueuedWorkerRequests parameter and fix plugin results at failures

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -157,8 +157,8 @@ var path = require('path'),
                 options: {}
             },
             // Default worker manager options (can be reused by custom worker managers too).
-            maxWorkers: 2,
-            maxQueuedWorkerRequests: 0,
+            maxWorkers: 10,
+            maxQueuedWorkerRequests: -1,
             workerDisconnectTimeout: 2000,
             log: {
                 //patterns: ['gme:server:*', '-gme:server:standalone*'],

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -154,10 +154,12 @@ var path = require('path'),
             timeout: -1,
             workerManager: {
                 path: path.join(__dirname, '../src/server/worker/serverworkermanager'),
-                disconnectTimeout: 2000,
                 options: {}
             },
-            maxWorkers: 10,
+            // Default worker manager options (can be reused by custom worker managers too).
+            maxWorkers: 2,
+            maxQueuedWorkerRequests: 0,
+            workerDisconnectTimeout: 2000,
             log: {
                 //patterns: ['gme:server:*', '-gme:server:standalone*'],
                 transports: [{

--- a/src/client/pluginmanager.js
+++ b/src/client/pluginmanager.js
@@ -125,7 +125,13 @@ define([
                 context.managerConfig.project = context.managerConfig.project.projectId;
             }
 
-            storage.simpleRequest({command: 'executePlugin', name: pluginId, context: context}, callback);
+            storage.simpleRequest({command: 'executePlugin', name: pluginId, context: context}, function (err, result) {
+                if (err) {
+                    callback(err, err.result);
+                } else {
+                    callback(null, result);
+                }
+            });
         };
 
         /**

--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -500,7 +500,8 @@ define([
                 });
             } else {
                 StorageObjectLoaders.prototype.setBranchHash.call(self,
-                    projectId, branchName, newHash, oldHash, callback);
+                    projectId, branchName, newHash, oldHash)
+                    .nodeify(callback);
             }
         };
 

--- a/src/common/storage/storageclasses/simpleapi.js
+++ b/src/common/storage/storageclasses/simpleapi.js
@@ -141,6 +141,9 @@ define(['common/storage/storageclasses/watchers'], function (StorageWatcher) {
             } else if (typeof kind === 'function') {
                 data.ownerId = ownerId;
                 callback = kind;
+            } else {
+                data.ownerId = ownerId;
+                data.kind = kind;
             }
         } else {
             data.ownerId = ownerId;

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -682,7 +682,7 @@ function StandAloneServer(gmeConfig) {
         fs.readFile(indexHtmlPath, 'utf8', function (err, indexTemp) {
             if (err) {
                 logger.error(err);
-                res.send(404);
+                res.sendStatus(404);
             } else {
                 res.contentType('text/html');
                 //http://stackoverflow.com/questions/49547/how-to-control-web-page-caching-across-all-browsers

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -91,11 +91,11 @@ function WorkerRequests(mainLogger, gmeConfig, webgmeUrl) {
 
             if (status === storage.CONSTANTS.DISCONNECTED) {
                 logger.warn('Connected worker got disconnected from server, awaiting reconnect',
-                    gmeConfig.server.workerManager.disconnectTimeout);
+                    gmeConfig.server.workerDisconnectTimeout);
 
                 timeoutId = setTimeout(function () {
                     finishFn(new Error('Unexpected network status: ' + status));
-                }, gmeConfig.server.workerManager.disconnectTimeout);
+                }, gmeConfig.server.workerDisconnectTimeout);
             } else if (status === storage.CONSTANTS.RECONNECTED) {
                 clearTimeout(timeoutId);
             } else if (UNRECOVERABLE_STATUSES.indexOf(status) > -1) {

--- a/test-karma/client/js/plugin.spec.js
+++ b/test-karma/client/js/plugin.spec.js
@@ -235,6 +235,36 @@ describe('Plugin', function () {
         });
     });
 
+    it('should run MinimalWorkingExample on the server and return results even though it failed', function (done) {
+        var pluginId = 'MinimalWorkingExample',
+            context = {
+                managerConfig: {
+                    project: client.getActiveProjectId(),
+                    activeNode: '',
+                    activeSelection: [],
+                    commit: client.getActiveCommitHash(),
+                    branchName: 'master'
+                },
+                pluginConfig: {
+                    save: false,
+                    shouldFail: true
+                }
+            };
+
+        client.runServerPlugin(pluginId, context, function (err, pluginResult) {
+            try {
+                expect(err instanceof Error).to.equal(true);
+                expect(err.message).to.include('Failed on purpose');
+                expect(pluginResult).to.have.keys(['artifacts', 'commits', 'error', 'finishTime', 'messages',
+                    'pluginName', 'pluginId', 'projectId', 'startTime', 'success']);
+                expect(pluginResult.success).to.equal(false);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    });
+
     it('should fork when client made changes after invocation', function (done) {
         var pluginId = 'PluginForked',
             context = {

--- a/test/common/storage/storageclasses/simpleapi.spec.js
+++ b/test/common/storage/storageclasses/simpleapi.spec.js
@@ -39,13 +39,13 @@ describe('storage storageclasses simpleapi', function () {
         pluginContext = {
             managerConfig: {
                 project: projectName2Id(projectName),
-                branch: 'b1',
+                branchName: 'b1',
                 commitHash: null,
                 activeNode: '/1'
             },
             pluginConfig: {
                 save: false,
-                fail: true
+                shouldFail: true
             }
         },
         importResult,
@@ -356,6 +356,57 @@ describe('storage storageclasses simpleapi', function () {
             .nodeify(done);
     });
 
+    it('should createProject with callback', function (done) {
+        var projName = 'newProjCb';
+        storage.createProject(projName, function (err, projectId) {
+            try {
+                expect(!err).to.equal(true);
+                expect(projectId).to.equal(projectName2Id(projName));
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    });
+
+    it('should createProject with owner and callback', function (done) {
+        var projName = 'newProjCb2';
+        storage.createProject(projName, 'guest', function (err, projectId) {
+            try {
+                expect(!err).to.equal(true);
+                expect(projectId).to.equal(projectName2Id(projName));
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+    });
+
+    it('should createProject with owner and kind and callback', function (done) {
+        var projName = 'newProjCb3';
+        storage.createProject(projName, 'guest', 'kindest', function (err, projectId) {
+            try {
+                expect(!err).to.equal(true);
+                expect(projectId).to.equal(projectName2Id(projName));
+                storage.getProjects({info: true})
+                    .then(function (projects) {
+                        var found = false;
+                        projects.forEach(function (project) {
+                            if (project._id === projectId) {
+                                expect(project.info.kind).to.equal('kindest');
+                                found = true;
+                            }
+                        });
+
+                        expect(found).to.equal(true);
+                    })
+                    .nodeify(done);
+            } catch (e) {
+                done(e);
+            }
+        });
+    });
+
     it('should fail to call createProject if project already exists', function (done) {
         storage.createProject(projectNameCreate2)
             .then(function (projectId) {
@@ -460,6 +511,7 @@ describe('storage storageclasses simpleapi', function () {
             function (err) {
                 try {
                     expect(!!err.result && typeof err.result === 'object').to.equal(true);
+                    expect(err.message).to.include('Failed on purpose');
                     expect(err.result).to.have.keys(['artifacts', 'commits', 'error', 'finishTime', 'messages',
                         'pluginName', 'pluginId', 'projectId', 'startTime', 'success']);
                     expect(err.result.success).to.equal(false);


### PR DESCRIPTION
Fixes [webgme#1570](https://github.com/webgme/webgme/issues/1570) details about failed plugin results are available.

This PR also fixes some minor bugs/improvements:
- passing kind in `createProject` works as it should
- use `res.sendStatus` in standalone.