### PR TITLE
Allow multiple watchers of documents sharing the same socket connection

### DIFF
--- a/src/common/storage/storageclasses/watchers.js
+++ b/src/common/storage/storageclasses/watchers.js
@@ -415,7 +415,7 @@ define([
                 var rejoinData = _splitDocId(docId);
                 rejoinData.docId = docId;
                 rejoinData.rejoin = true;
-                rejoinData.revision = self.watchers.documents[docId].otClient.revision;
+                rejoinData.revision = self.watchers.documents[docId][watcherId].otClient.revision;
                 rejoinData.sessionId = self.watchers.sessionId;
                 rejoinData.watcherId = watcherId;
 

--- a/src/common/storage/storageclasses/watchers.js
+++ b/src/common/storage/storageclasses/watchers.js
@@ -177,12 +177,10 @@ define([
             eventHandler: function (_ws, eData) {
                 var otClient = self.watchers.documents[eData.docId][watcherId].otClient;
                 self.logger.debug('eventHandler for document', {metadata: eData});
-                if (eData.sessionId === self.watchers.sessionId) {
-                    self.logger.info('event from same client');
-                    if (eData.watcherId === watcherId) {
-                        self.logger.info('event from same watcher, skipping...');
-                        return;
-                    }
+
+                if (eData.watcherId === watcherId) {
+                    self.logger.info('event from same watcher, skipping...');
+                    return;
                 }
 
                 if (eData.operation) {

--- a/src/plugin/coreplugins/OTAttributeEditing/metadata.json
+++ b/src/plugin/coreplugins/OTAttributeEditing/metadata.json
@@ -8,7 +8,7 @@
     "src": ""
   },
   "disableServerSideExecution": false,
-  "disableBrowserSideExecution": true,
+  "disableBrowserSideExecution": false,
   "writeAccessRequired": true,
   "configStructure": [
     {

--- a/src/server/storage/documentserver.js
+++ b/src/server/storage/documentserver.js
@@ -58,7 +58,7 @@ DocumentServer.prototype.onOperation = function (data) {
     wrapped = new WrappedOperation(
         TextOperation.fromJSON(data.operation),
         data.selection && Selection.fromJSON(data.selection),
-        {userId: data.userId, sessionId: data.sessionId});
+        {userId: data.userId, sessionId: data.sessionId, watcherId: data.watcherId});
 
 
     return this.receiveOperation(data.revision, wrapped);

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -299,7 +299,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                 });
 
                                 document.disconnectedUsers[document.users[socket.id].sessionId] =
-                                    document.users[socket.id].watcherId;
+                                    document.users[socket.id].watchers;
 
                                 delete document.users[socket.id];
 

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -1049,6 +1049,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                 };
 
                                 socket.join(docId);
+                            } else {
+                                documents[docId].users[socket.id].watchers.push(data.watcherId);
                             }
 
                             callback(null, {

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -1073,7 +1073,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                 };
 
                                 if (documents[docId].users[socket.id].watchers.length > 1) {
-                                    socket.emit.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
+                                    webSocket.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
                                 } else {
                                     socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
                                 }
@@ -1135,7 +1135,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                     };
                     // and then broadcast or emit the operation.
                     if (documents[data.docId].users[socket.id].watchers.length > 1) {
-                        socket.emit.to(data.docId).emit(CONSTANTS.DOCUMENT_OPERATION, eventData);
+                        webSocket.to(data.docId).emit(CONSTANTS.DOCUMENT_OPERATION, eventData);
                     } else {
                         socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_OPERATION, eventData);
                     }
@@ -1177,7 +1177,7 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                     };
 
                     if (documents[data.docId].users[socket.id].watchers.length > 1) {
-                        socket.emit.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
+                        webSocket.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
                     } else {
                         socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
                     }

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -298,7 +298,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                     selection: null
                                 });
 
-                                document.disconnectedUsers[document.users[socket.id].sessionId] = true;
+                                document.disconnectedUsers[document.users[socket.id].sessionId] =
+                                    document.users[socket.id].watcherId;
 
                                 delete document.users[socket.id];
 
@@ -953,14 +954,16 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             socket.on('watchDocument', function (data, callback) {
                 projectAccess(socket, data && data.webgmeToken, data && data.projectId)
                     .then(function (access) {
-                        var docId = data.join ? [
-                            data.projectId,
-                            data.branchName,
-                            data.nodeId,
-                            data.attrName].join(CONSTANTS.ROOM_DIVIDER) : data.docId;
+                        var docId = data.join ? [data.projectId, data.branchName, data.nodeId, data.attrName]
+                                .join(CONSTANTS.ROOM_DIVIDER) : data.docId,
+                            eventData;
 
                         if (!gmeConfig.documentEditing.enable) {
                             throw new Error('Document editing is disabled from gmeConfig!');
+                        }
+
+                        if (typeof data.watcherId !== 'string') {
+                            throw new Error('data.watcherId was not provided!');
                         }
 
                         logger.debug('watchDocument', docId, 'join?', data.join, 'rejoin?', data.rejoin);
@@ -988,16 +991,19 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                     socketId: socket.id,
                                     sessionId: data.sessionId,
                                     userId: socket.userId,
-                                    access: access
+                                    access: access,
+                                    watchers: [data.watcherId]
                                 };
 
                                 socket.join(docId);
                             } else {
-                                logger.warn('socket trying to join same document again..', docId);
+                                logger.info('socket joining the same document again', docId);
+                                documents[docId].users[socket.id].watchers.push(data.watcherId);
                             }
 
                             callback(null, {
                                 docId: docId,
+                                watcherId: data.watcherId,
                                 document: documents[docId].otServer.document,
                                 revision: documents[docId].otServer.operations.length,
                                 clients: documents[docId].users
@@ -1017,42 +1023,72 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                                 throw new Error('Document room was closed ' + docId);
                             } else if (documents[docId].disconnectedUsers.hasOwnProperty(data.sessionId) === false) {
                                 throw new Error('Document room was closed ' + docId + ' and then reopened.');
+                            } else if (documents[docId].disconnectedUsers[data.sessionId].indexOf(
+                                data.watcherId) === -1) {
+                                throw new Error('Document room to rejoin ' + docId + ' did not have current watcher.');
                             }
 
                             documents[docId].otServer.getOperationsSince(data.revision);
 
-                            delete documents[docId].disconnectedUsers[data.sessionId];
+                            documents[docId].disconnectedUsers[data.sessionId].splice(
+                                documents[docId].disconnectedUsers[data.sessionId].indexOf(data.watcherId), 1);
+
                             clearTimeout(documents[docId].timeoutId);
 
-                            documents[docId].users[socket.id] = {
-                                socketId: socket.id,
-                                userId: socket.userId,
-                                sessionId: data.sessionId,
-                                access: access
-                            };
+                            if (documents[docId].disconnectedUsers[data.sessionId].length === 0) {
+                                delete documents[docId].disconnectedUsers[data.sessionId];
+                            }
 
-                            socket.join(docId);
+                            if (documents[docId].users.hasOwnProperty(socket.id) === false) {
+                                documents[docId].users[socket.id] = {
+                                    socketId: socket.id,
+                                    userId: socket.userId,
+                                    sessionId: data.sessionId,
+                                    access: access,
+                                    watchers: [data.watcherId]
+                                };
+
+                                socket.join(docId);
+                            }
 
                             callback(null, {
                                 docId: docId,
+                                watcherId: data.watcherId,
                                 str: documents[docId].otServer.document,
                                 revision: documents[docId].otServer.operations.length,
                                 operations: documents[docId].otServer.getOperationsSince(data.revision),
                                 clients: documents[docId].users
                             });
                         } else {
-                            if (documents.hasOwnProperty(docId) && documents[docId].users.hasOwnProperty(socket.id)) {
-                                socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, {
+                            if (documents.hasOwnProperty(docId) &&
+                                documents[docId].users.hasOwnProperty(socket.id) &&
+                                documents[docId].users[socket.id].watchers.indexOf(data.watcherId) > -1) {
+
+                                eventData = {
                                     docId: data.docId,
                                     socketId: socket.id,
                                     userId: socket.userId,
+                                    watcherId: data.watcherId,
                                     selection: null
-                                });
+                                };
 
-                                delete documents[docId].users[socket.id];
-                                socket.leave(docId);
-                                logger.debug('Client left document', docId);
-                                triggerDocumentRemoval(docId);
+                                if (documents[docId].users[socket.id].watchers.length > 1) {
+                                    socket.emit.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
+                                } else {
+                                    socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
+                                }
+
+                                // Remove the watcherId
+                                documents[docId].users[socket.id].watchers.splice(
+                                    documents[docId].users[socket.id].watchers.indexOf(data.watcherId), 1);
+
+                                if (documents[docId].users[socket.id].watchers.length === 0) {
+                                    // Last watcher from this socket - leave the room and clean-up.
+                                    delete documents[docId].users[socket.id];
+                                    socket.leave(docId);
+                                    logger.debug('Client left document', docId);
+                                    triggerDocumentRemoval(docId);
+                                }
 
                                 callback();
                             } else {
@@ -1068,28 +1104,40 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on(CONSTANTS.DOCUMENT_OPERATION, function (data, callback) {
-                var wrappedOperation;
+                var wrappedOperation,
+                    eventData;
 
                 try {
-                    if (documents.hasOwnProperty(data.docId) && documents[data.docId].users.hasOwnProperty(socket.id)) {
-                        if (documents[data.docId].users[socket.id].access.write === true) {
-                            data.userId = documents[data.docId].users[socket.id].userId;
-                            wrappedOperation = documents[data.docId].otServer.onOperation(data);
-                            // Acknowledge,
-                            callback();
-                            // and then broadcast the operation.
-                            socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_OPERATION, {
-                                docId: data.docId,
-                                socketId: socket.id,
-                                userId: socket.userId,
-                                operation: wrappedOperation.wrapped.toJSON(),
-                                selection: wrappedOperation.selection
-                            });
-                        } else {
-                            throw new Error('Does not have write access to document');
-                        }
-                    } else {
+                    if (typeof data.watcherId !== 'string') {
+                        throw new Error('data.watcherId not provided!');
+                    }
+
+                    if (documents.hasOwnProperty(data.docId) === false ||
+                        documents[data.docId].users.hasOwnProperty(socket.id) === false) {
                         throw new Error('Client not watching document - cannot send operation!');
+                    }
+
+                    if (documents[data.docId].users[socket.id].access.write !== true) {
+                        throw new Error('Does not have write access to document');
+                    }
+
+                    data.userId = documents[data.docId].users[socket.id].userId;
+                    wrappedOperation = documents[data.docId].otServer.onOperation(data);
+                    // Acknowledge,
+                    callback();
+                    eventData = {
+                        docId: data.docId,
+                        watcherId: data.watcherId,
+                        socketId: socket.id,
+                        userId: socket.userId,
+                        operation: wrappedOperation.wrapped.toJSON(),
+                        selection: wrappedOperation.selection
+                    };
+                    // and then broadcast or emit the operation.
+                    if (documents[data.docId].users[socket.id].watchers.length > 1) {
+                        socket.emit.to(data.docId).emit(CONSTANTS.DOCUMENT_OPERATION, eventData);
+                    } else {
+                        socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_OPERATION, eventData);
                     }
                 } catch (err) {
                     logger.error(err.stack, '\n', (new Error('Caught by')).stack);
@@ -1098,7 +1146,8 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
             });
 
             socket.on(CONSTANTS.DOCUMENT_SELECTION, function (data, callback) {
-                var transformedSelection;
+                var transformedSelection,
+                    eventData;
 
                 function done(err) {
                     if (callback) {
@@ -1107,22 +1156,33 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                 }
 
                 try {
-                    if (documents.hasOwnProperty(data.docId) && documents[data.docId].users.hasOwnProperty(socket.id)) {
+                    if (typeof data.watcherId !== 'string') {
+                        throw new Error('data.watcherId not provided!');
+                    }
 
-                        transformedSelection = documents[data.docId].otServer.onSelection(
-                            data.revision, data.selection);
-
-                        socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, {
-                            docId: data.docId,
-                            socketId: socket.id,
-                            userId: socket.userId,
-                            selection: transformedSelection
-                        });
-                        done();
-
-                    } else {
+                    if (documents.hasOwnProperty(data.docId) === false ||
+                        documents[data.docId].users.hasOwnProperty(socket.id) === false) {
                         throw new Error('Client not watching document - cannot send selection!');
                     }
+
+
+                    transformedSelection = documents[data.docId].otServer.onSelection(data.revision, data.selection);
+
+                    eventData = {
+                        docId: data.docId,
+                        socketId: socket.id,
+                        userId: socket.userId,
+                        watcherId: data.watcherId,
+                        selection: transformedSelection
+                    };
+
+                    if (documents[data.docId].users[socket.id].watchers.length > 1) {
+                        socket.emit.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
+                    } else {
+                        socket.broadcast.to(data.docId).emit(CONSTANTS.DOCUMENT_SELECTION, eventData);
+                    }
+
+                    done();
                 } catch (err) {
                     logger.error(err.stack, '\n', (new Error('Caught by')).stack);
                     done(err);

--- a/test/common/storage/storageclasses/connection.spec.js
+++ b/test/common/storage/storageclasses/connection.spec.js
@@ -742,6 +742,7 @@ describe('storage-connection', function () {
                 },
                 docId,
                 res,
+                watcherId,
                 storage;
 
             server = WebGME.standaloneServer(gmeConfig);
@@ -759,14 +760,16 @@ describe('storage-connection', function () {
                             storage.watchDocument(docData, testFixture.noop, testFixture.noop)
                                 .then(function (result) {
                                     docId = result.docId;
+                                    watcherId = result.watcherId;
                                     res.socket.disconnect();
 
                                     storage.sendDocumentOperation({
                                         docId: docId,
+                                        watcherId: watcherId,
                                         operation: new ot.TextOperation().insert('yello')
                                     });
 
-                                    expect(storage.watchers.documents[docId].otClient.state instanceof
+                                    expect(storage.watchers.documents[docId][watcherId].otClient.state instanceof
                                         ot.Client.AwaitingConfirm).to.equal(true);
                                 })
                                 .catch(deferred.reject);
@@ -782,9 +785,9 @@ describe('storage-connection', function () {
                                     // Reconnected should come before the ack of the sent documentation
                                     // (the document never reached the server since we disconnected before
                                     // sending it)
-                                    expect(storage.watchers.documents[docId].otClient.state instanceof
+                                    expect(storage.watchers.documents[docId][watcherId].otClient.state instanceof
                                         ot.Client.AwaitingConfirm).to.equal(true);
-                                    storage.unwatchDocument({docId: docId})
+                                    storage.unwatchDocument({docId: docId, watcherId: watcherId})
                                         .then(function () {
                                             deferred.resolve();
                                         })
@@ -825,6 +828,7 @@ describe('storage-connection', function () {
                     attrValue: ''
                 },
                 docId,
+                watcherId,
                 res,
                 storage;
 
@@ -843,9 +847,11 @@ describe('storage-connection', function () {
                             storage.watchDocument(docData, testFixture.noop, testFixture.noop)
                                 .then(function (result) {
                                     docId = result.docId;
+                                    watcherId = result.watcherId;
 
                                     storage.sendDocumentOperation({
                                         docId: docId,
+                                        watcherId: watcherId,
                                         operation: new ot.TextOperation().insert('yello')
                                     });
 
@@ -855,7 +861,7 @@ describe('storage-connection', function () {
                                         res.socket.disconnect();
                                     };
 
-                                    expect(storage.watchers.documents[docId].otClient.state instanceof
+                                    expect(storage.watchers.documents[docId][watcherId].otClient.state instanceof
                                         ot.Client.AwaitingConfirm).to.equal(true);
                                 })
                                 .catch(deferred.reject);
@@ -869,9 +875,9 @@ describe('storage-connection', function () {
                             if (disconnected === true) {
                                 try {
                                     // In should be synchronized since the sent document did indeed reach the server.
-                                    expect(storage.watchers.documents[docId].otClient.state instanceof
+                                    expect(storage.watchers.documents[docId][watcherId].otClient.state instanceof
                                         ot.Client.Synchronized).to.equal(true);
-                                    storage.unwatchDocument({docId: docId})
+                                    storage.unwatchDocument({docId: docId, watcherId: watcherId})
                                         .then(function () {
                                             deferred.resolve();
                                         })
@@ -917,6 +923,8 @@ describe('storage-connection', function () {
                 res2,
                 storage,
                 storage2,
+                watcherId1,
+                watcherId2,
                 revision,
                 server = WebGME.standaloneServer(gmeConfig);
 
@@ -944,12 +952,15 @@ describe('storage-connection', function () {
                                     ])
                                         .then(function (result) {
                                             docId = result[0].docId;
+                                            watcherId1 = result[0].watcherId;
+                                            watcherId2 = result[1].watcherId;
                                             storage2.sendDocumentOperation({
                                                 docId: docId,
+                                                watcherId: watcherId2,
                                                 operation: new ot.TextOperation().insert('yello')
                                             });
 
-                                            revision = storage.watchers.documents[docId].otClient.revision;
+                                            revision = storage.watchers.documents[docId][watcherId1].otClient.revision;
 
                                             res.socket.disconnect();
                                         })
@@ -967,14 +978,14 @@ describe('storage-connection', function () {
                                 try {
                                     // In should be synchronized since the operation from the other client
                                     // should be retrieved at rejoin.
-                                    expect(storage.watchers.documents[docId].otClient.state instanceof
+                                    expect(storage.watchers.documents[docId][watcherId1].otClient.state instanceof
                                         ot.Client.Synchronized).to.equal(true);
 
-                                    expect(storage.watchers.documents[docId].otClient.revision).to.equal(revision + 1,
-                                        'Other clients change was not retrieved after rejoin.');
+                                    expect(storage.watchers.documents[docId][watcherId1].otClient.revision)
+                                        .to.equal(revision + 1, 'Other clients change was not retrieved after rejoin.');
                                     Q.allDone([
-                                        storage.unwatchDocument({docId: docId}),
-                                        storage2.unwatchDocument({docId: docId})
+                                        storage.unwatchDocument({docId: docId, watcherId: watcherId1}),
+                                        storage2.unwatchDocument({docId: docId, watcherId: watcherId2})
                                     ])
                                         .then(function () {
                                             if (opHandlerCalled) {
@@ -1025,6 +1036,7 @@ describe('storage-connection', function () {
                 docId,
                 res,
                 storage,
+                watcherId,
                 modifiedConfig = JSON.parse(JSON.stringify(gmeConfig));
 
             modifiedConfig.socketIO.clientOptions.autoConnect = false;
@@ -1045,15 +1057,17 @@ describe('storage-connection', function () {
                             storage.watchDocument(docData, testFixture.noop, testFixture.noop)
                                 .then(function (result) {
                                     docId = result.docId;
+                                    watcherId = result.watcherId;
 
                                     res.socket.disconnect();
 
                                     storage.sendDocumentOperation({
                                         docId: docId,
+                                        watcherId: watcherId,
                                         operation: new ot.TextOperation().insert('yello')
                                     });
 
-                                    expect(storage.watchers.documents[docId].otClient.state instanceof
+                                    expect(storage.watchers.documents[docId][watcherId].otClient.state instanceof
                                         ot.Client.AwaitingConfirm).to.equal(true);
                                 })
                                 .catch(deferred.reject);
@@ -1103,6 +1117,7 @@ describe('storage-connection', function () {
                 res2,
                 storage,
                 storage2,
+                watcherId2,
                 server,
                 modifiedConfig = JSON.parse(JSON.stringify(gmeConfig));
 
@@ -1132,6 +1147,7 @@ describe('storage-connection', function () {
                                     storage.watchDocument(docData, testFixture.noop, testFixture.noop)
                                         .then(function (result) {
                                             docId = result.docId;
+                                            // watcherId1 = result.watcherId;
                                             // 2. Client 1 gets disconnected and removal triggered on server.
                                             res.socket.disconnect();
                                         })
@@ -1146,7 +1162,10 @@ describe('storage-connection', function () {
                                 // 3. Wait till the document has been closed (100 > 10 ms)
                                 // and open it with Client 2
                                 setTimeout(function () {
-                                    storage2.watchDocument(docData, testFixture.noop, testFixture.noop);
+                                    storage2.watchDocument(docData, testFixture.noop, testFixture.noop)
+                                        .then(function (initData) {
+                                            watcherId2 = initData.watcherId;
+                                        });
                                 }, 100);
                             } else {
                                 deferred.reject(new Error('Was not connected before reconnected'));
@@ -1154,7 +1173,7 @@ describe('storage-connection', function () {
                         } else if (networkState === STORAGE_CONSTANTS.CONNECTION_ERROR) {
                             // 4. Client 1 should get an error at reconnect.
                             if (disconnected === true) {
-                                storage2.unwatchDocument({docId: docId})
+                                storage2.unwatchDocument({docId: docId, watcherId: watcherId2})
                                     .then(deferred.resolve)
                                     .catch(deferred.reject);
                             } else {

--- a/test/common/storage/storageclasses/watchers_documents.spec.js
+++ b/test/common/storage/storageclasses/watchers_documents.spec.js
@@ -615,11 +615,11 @@ describe('watchers documents', function () {
             })
             .then(function (res) {
                 users['user1'].docId = res.docId;
-                users['user1'].watchers = [res.watcherId];
+                users['user1'].watchers.push(res.watcherId);
                 return storage.watchDocument(testFixture.copy(initParams), noop, noop);
             })
             .then(function (res) {
-                users['user1'].watchers = [res.watcherId];
+                users['user1'].watchers.push(res.watcherId);
                 expect(Object.keys(storage.watchers.documents[docId]).length).to.equal(2);
             })
             .nodeify(done);

--- a/test/plugin/coreplugins/OTAttributeEditing/OTAttributeEditing.spec.js
+++ b/test/plugin/coreplugins/OTAttributeEditing/OTAttributeEditing.spec.js
@@ -102,6 +102,7 @@ describe('OTAttributeEditing Plugin', function () {
             storage = testFixture.getConnectedStorage(gmeConfig, logger),
             connProject,
             docId,
+            watcherId,
             doc;
 
         function atOperation(op) {
@@ -127,6 +128,7 @@ describe('OTAttributeEditing Plugin', function () {
             .then(function (res) {
                 doc = res.document;
                 docId = res.docId;
+                watcherId = res.watcherId;
                 return Q.ninvoke(wr, 'executePlugin', null, null, 'OTAttributeEditing', context);
             })
             .then(function (res) {
@@ -142,7 +144,7 @@ describe('OTAttributeEditing Plugin', function () {
                 expect(attr).to.equal(doc);
                 expect((attr.match(/This is output nr/g) || []).length).to.equal(context.pluginConfig.cycles);
 
-                return connProject.unwatchDocument({docId: docId});
+                return connProject.unwatchDocument({docId: docId, watcherId: watcherId});
             })
             .then(function () {
                 return Q.ninvoke(storage, 'close');
@@ -165,6 +167,7 @@ describe('OTAttributeEditing Plugin', function () {
             cnt = 0,
             connProject,
             docId,
+            watcherId,
             doc;
 
         function atOperation(op) {
@@ -184,6 +187,7 @@ describe('OTAttributeEditing Plugin', function () {
             setTimeout(function () {
                 connProject.sendDocumentOperation({
                     docId: docId,
+                    watcherId: watcherId,
                     operation: newOperation
                 });
             });
@@ -208,6 +212,7 @@ describe('OTAttributeEditing Plugin', function () {
             .then(function (res) {
                 doc = res.document;
                 docId = res.docId;
+                watcherId = res.watcherId;
                 return Q.ninvoke(wr, 'executePlugin', null, null, 'OTAttributeEditing', context);
             })
             .then(function (res) {
@@ -224,7 +229,7 @@ describe('OTAttributeEditing Plugin', function () {
                 expect((attr.match(/This is output nr/g) || []).length).to.equal(context.pluginConfig.cycles);
                 expect((attr.match(/Added by test watcher/g) || []).length).to.equal(cnt);
 
-                return connProject.unwatchDocument({docId: docId});
+                return connProject.unwatchDocument({docId: docId, watcherId: watcherId});
             })
             .then(function () {
                 return Q.ninvoke(storage, 'close');

--- a/test/server/storage/websocket.spec.js
+++ b/test/server/storage/websocket.spec.js
@@ -751,7 +751,8 @@ describe('WebSocket', function () {
             var socket,
                 data = {
                     docId: 'guest+SomeProject%someBranch%someNodeId%someAttrName',
-                    watcherId: 'some-random-id'
+                    watcherId: 'some-random-id',
+                    webgmeToken: webgmeToken
                 };
 
             openSocketIo()
@@ -759,13 +760,18 @@ describe('WebSocket', function () {
                     socket = socket_;
                     return Q.allSettled([
                         Q.ninvoke(socket, 'emit', CONSTANTS.DOCUMENT_OPERATION, data),
-                        Q.ninvoke(socket, 'emit', CONSTANTS.DOCUMENT_SELECTION, data)
+                        Q.ninvoke(socket, 'emit', CONSTANTS.DOCUMENT_SELECTION, data),
+                        Q.ninvoke(socket, 'emit', 'watchDocument', data)
                     ]);
                 })
                 .then(function (result) {
                     result.forEach(function (res, i) {
-                        expect(res.state).to.equal('rejected', i);
-                        expect(res.reason).to.include('Client not watching document');
+                        if (i === 2) {
+                            expect(res.state).to.equal('fulfilled', i);
+                        } else {
+                            expect(res.state).to.equal('rejected', i);
+                            expect(res.reason).to.include('Client not watching document');
+                        }
                     });
 
                     // Check that we can still e.g. openProject.

--- a/test/server/storage/websocket.spec.js
+++ b/test/server/storage/websocket.spec.js
@@ -750,7 +750,8 @@ describe('WebSocket', function () {
         it('should return error at DOCUMENT_OPERATION/DOCUMENT_SELECTION when not watching document', function (done) {
             var socket,
                 data = {
-                    docId: 'guest+SomeProject%someBranch%someNodeId%someAttrName'
+                    docId: 'guest+SomeProject%someBranch%someNodeId%someAttrName',
+                    watcherId: 'some-random-id'
                 };
 
             openSocketIo()
@@ -785,6 +786,7 @@ describe('WebSocket', function () {
                     return Q.ninvoke(socket, 'emit', 'watchDocument', {
                         projectId: 'guest+SomeProject',
                         docId: 'guest+SomeProject%someBranch%someNodeId%someAttrName',
+                        watcherId: 'some-random-id',
                         rejoin: true,
                         webgmeToken: webgmeToken
                     });
@@ -912,7 +914,7 @@ describe('WebSocket', function () {
                 .then(function (result) {
                     result.forEach(function (res, i) {
                         var shouldSucceed = [
-                            0, 1, 2, 3, 7, 27
+                            0, 1, 2, 3, 7
                         ];
                         if (shouldSucceed.indexOf(i) > -1) {
                             expect(res.state).to.equal('fulfilled', i);
@@ -942,7 +944,7 @@ describe('WebSocket', function () {
                 .then(function (result) {
                     result.forEach(function (res, i) {
                         var shouldSucceed = [
-                            0, 1, 2, 3, 7, 27
+                            0, 1, 2, 3, 7
                         ];
                         if (shouldSucceed.indexOf(i) > -1) {
                             expect(res.state).to.equal('fulfilled', i);
@@ -972,7 +974,7 @@ describe('WebSocket', function () {
                 .then(function (result) {
                     result.forEach(function (res, i) {
                         var shouldSucceed = [
-                            0, 1, 2, 3, 7, 27
+                            0, 1, 2, 3, 7
                         ];
                         if (shouldSucceed.indexOf(i) > -1) {
                             expect(res.state).to.equal('fulfilled', i);

--- a/test/server/worker/workermanager.spec.js
+++ b/test/server/worker/workermanager.spec.js
@@ -231,7 +231,7 @@ describe('ServerWorkerManager - SimpleWorkers', function () {
         });
     });
 
-    describe.only('maximum queued requests', function () {
+    describe('maximum queued requests', function () {
         var swm;
 
         afterEach(function (done) {


### PR DESCRIPTION
Now with more than a single, the `watcherId` needs to be supplied in `data` at:
`sendDocumentOperation(data, ..)`
`sendDocumentSelection(data, ..)`
`unwatchDocument(data, ..)`.

The watcherId is returned in the resolved object at `watchDocument`.

Related to:
[webgme#1572](https://github.com/webgme/webgme/issues/1572)