### PR TITLE
Support creation of test projects from "json" objects

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -55,7 +55,7 @@ define([
                 projectInfo: null,
                 core: null,
                 branchName: null,
-                branchStatus: null, //CONSTANTS.BRANCH_STATUS. SYNC/AHEAD_SYNC/AHEAD_FORKED/PULLING/ERROR or null
+                branchStatus: null, //CONSTANTS.BRANCH_STATUS. SYNC/AHEAD_SYNC/AHEAD_NOT_SYNC/PULLING/ERROR or null
                 readOnlyProject: false,
                 viewer: false, // This means that a specific commit is selected w/o regards to any branch.
 

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -443,10 +443,10 @@ function importProject(storage, parameters, callback) {
             })
             .catch(extractDeferred.reject);
     } else if (typeof parameters.projectSeed === 'object') {
-        extractDeferred.reject(new Error('json file:', parameters.projectSeed));
         extractDeferred.resolve(parameters.projectSeed);
     } else {
-        extractDeferred.reject('parameters.projectSeed must be filePath to a webgmex file');
+        extractDeferred.reject(new Error('parameters.projectSeed must be filePath to a webgmex file ' +
+            'or a json of the project content.'));
     }
     branchName = parameters.branchName || 'master';
     // Parameters check end.

--- a/test/seeds/project.json
+++ b/test/seeds/project.json
@@ -1,0 +1,166 @@
+{
+  "rootHash": "#4649fd96b7356499351a6e37abbc6321b95ebc5e",
+  "projectId": "guest+EmptyProject",
+  "commitHash": "#0fe7dc4b9953956fc53a5b861d150fa5decc345b",
+  "hashes": {
+    "objects": [
+      "#4649fd96b7356499351a6e37abbc6321b95ebc5e",
+      "#d51484d046f593d83a9e9663346a3c93f80d9018"
+    ],
+    "assets": []
+  },
+  "objects": [
+    {
+      "1": "#d51484d046f593d83a9e9663346a3c93f80d9018",
+      "_id": "#4649fd96b7356499351a6e37abbc6321b95ebc5e",
+      "_nullptr": {
+        "atr": {
+          "name": "_null_pointer"
+        }
+      },
+      "ovr": {
+        "": {
+          "base": "/_nullptr"
+        },
+        "/_sets/MetaAspectSet/1133782405": {
+          "member": "/1"
+        },
+        "/_sets/MetaAspectSet_68f8146d-b1b7-6c40-3464-f8c070e97e8d/125899614": {
+          "member": "/1"
+        },
+        "/_meta/children/_sets/items/302362349": {
+          "member": "/1"
+        }
+      },
+      "atr": {
+        "_relguid": "03d360729e097866cb4ed0a36ff825f6",
+        "name": "ROOT"
+      },
+      "reg": {
+        "MetaSheets": [
+          {
+            "SetID": "MetaAspectSet_68f8146d-b1b7-6c40-3464-f8c070e97e8d",
+            "order": 0,
+            "title": "META"
+          }
+        ],
+        "ProjectRegistry": {
+          "FCO_ID": "/1"
+        },
+        "_sets_": 8
+      },
+      "_sets": {
+        "MetaAspectSet": {
+          "1133782405": {
+            "reg": {
+              "_": "_",
+              "position": {
+                "x": 100,
+                "y": 100
+              }
+            }
+          },
+          "reg": {
+            "_": "_"
+          }
+        },
+        "_nullptr": {
+          "atr": {
+            "name": "_null_pointer"
+          }
+        },
+        "ovr": {
+          "": {
+            "MetaAspectSet": "/_nullptr",
+            "MetaAspectSet_68f8146d-b1b7-6c40-3464-f8c070e97e8d": "/_nullptr"
+          }
+        },
+        "MetaAspectSet_68f8146d-b1b7-6c40-3464-f8c070e97e8d": {
+          "125899614": {
+            "reg": {
+              "_": "_",
+              "position": {
+                "x": 100,
+                "y": 100
+              }
+            }
+          },
+          "reg": {
+            "_": "_"
+          }
+        }
+      },
+      "_meta": {
+        "atr": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "children": {
+          "_sets": {
+            "items": {
+              "302362349": {
+                "reg": {
+                  "_": "_"
+                },
+                "atr": {
+                  "min": -1,
+                  "max": -1
+                }
+              },
+              "reg": {
+                "_": "_"
+              }
+            },
+            "_nullptr": {
+              "atr": {
+                "name": "_null_pointer"
+              }
+            },
+            "ovr": {
+              "": {
+                "items": "/_nullptr"
+              }
+            }
+          },
+          "reg": {
+            "_sets_": 4
+          }
+        }
+      },
+      "__v": "1.1.0"
+    },
+    {
+      "_id": "#d51484d046f593d83a9e9663346a3c93f80d9018",
+      "_nullptr": {
+        "atr": {
+          "name": "_null_pointer"
+        }
+      },
+      "ovr": {
+        "": {
+          "base": "/_nullptr"
+        }
+      },
+      "atr": {
+        "_relguid": "de5a7e097ce3914f3d834f0c20e7e5b3",
+        "name": "FCO"
+      },
+      "reg": {
+        "DisplayFormat": "$name",
+        "position": {
+          "x": 80,
+          "y": 70
+        }
+      },
+      "_meta": {
+        "atr": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "__v": "1.1.0"
+    }
+  ]
+}

--- a/test/seeds/seeds.spec.js
+++ b/test/seeds/seeds.spec.js
@@ -76,6 +76,20 @@ describe('Seeds', function () {
         });
     });
 
+    it('testFixture createProject should accept json structure', function (done) {
+        testFixture.importProject(safeStorage, {
+            projectSeed: require('./project.json'),
+            projectName: 'createFromJson',
+            branchName: 'master',
+            gmeConfig: gmeConfig,
+            logger: logger
+        })
+            .then(function (ir) {
+                expect(ir.rootHash).to.equal(require('./project.json').rootHash);
+            })
+            .nodeify(done);
+    });
+
     // get seed designs 'files' and make sure all of them are getting tested
     it('should get all seed project names', function (done) {
         var agent = superagent.agent();


### PR DESCRIPTION
This will avoid check-ins of binary files for test projects.
To load in seed simply use `require` as shown below:

```javascript
        testFixture.importProject(safeStorage, {
            projectSeed: require('./project.json'),
            projectName: 'createFromJson',
            branchName: 'master',
            gmeConfig: gmeConfig,
            logger: logger
        })
```