### PR TITLE
Use the plugin.result as default result value. Fixes #52

### DIFF
--- a/src/plugin/managerbase.js
+++ b/src/plugin/managerbase.js
@@ -275,9 +275,8 @@ define([
 
             plugin.main(function (err, result) {
                 var stackTrace;
-                if (result) {
-                    self.logger.debug('plugin main callback called', {result: result.serialize()});
-                }
+                result = result || plugin.result;
+                self.logger.debug('plugin main callback called', {result: result.serialize()});
                 mainCallbackCalls += 1;
                 // set common information (meta info) about the plugin and measured execution times
                 result.setFinishTime((new Date()).toISOString());


### PR DESCRIPTION
Currently, line 282 will fail if `result` is not set. In this PR, I set the `result` value to `plugin.result` if it isn't set as an unset `result` will throw an exception and I have never passed anything other than `plugin.result` (so it seemed like a safe default ;) )
