### PR TITLE
Fix tests checking for invalid regular expressions which changed around node v8.10.0

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -973,7 +973,7 @@ define([
                         });
                     } else {
                         logger.warn('No branches available in project, will attempt to select latest commit.');
-                        self.getCommits(projectId, (new Date()).getTime(), 1, function (err, commitObjects) {
+                        self.getCommits(projectId, Date.now(), 1, function (err, commitObjects) {
                             if (err || commitObjects.length === 0) {
                                 logger.error(err);
                                 closeProject(projectId, function (err) {
@@ -1287,7 +1287,7 @@ define([
                 callback('Cannot fork without an open branch!');
                 return;
             }
-            forkName = newName || activeBranchName + '_' + (new Date()).getTime();
+            forkName = newName || activeBranchName + '_' + Date.now();
             storage.forkBranch(activeProjectId, activeBranchName, forkName, commitHash,
                 function (err, forkHash) {
                     if (err) {

--- a/src/common/storage/constants.js
+++ b/src/common/storage/constants.js
@@ -32,7 +32,7 @@
  * @prop {module:Storage~CommitHash} _id - Hash of the commit object, a.k.a commitHash.
  * @prop {module:Core~ObjectHash} root - Hash of the associated root object, a.k.a. rootHash.
  * @prop {module:Storage~CommitHash[]} parents - Commits from where this commit evolved.
- * @prop {number} time - When the commit object was created (new Date()).getTime().
+ * @prop {number} time - When the commit object was created Date.now().
  * @prop {string} message - Commit message.
  * @prop {string[]} updater - Commit message.
  * @prop {string} type - 'commit'

--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -700,7 +700,7 @@ define([
                     root: rootHash,
                     parents: parents,
                     updater: [self.userId],
-                    time: (new Date()).getTime(),
+                    time: Date.now(),
                     message: msg,
                     type: CONSTANTS.COMMIT_TYPE,
                     __v: CONSTANTS.VERSION

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -505,7 +505,7 @@ define([
         // User can set self.forkName, but must make sure it is unique.
         var self = this,
             oldBranchName = self.branchName,
-            forkName = self.forkName || self.branchName + '_' + (new Date()).getTime();
+            forkName = self.forkName || self.branchName + '_' + Date.now();
         self.logger.warn('Plugin got forked from "' + self.branchName + '". ' +
             'Trying to create a new branch "' + forkName + '".');
 

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -1417,7 +1417,7 @@ function createAPI(app, mountPath, middlewareOpts) {
                 username: userId,
                 projectId: StorageUtil.getProjectIdFromOwnerIdAndProjectName(req.params.ownerId,
                     req.params.projectName),
-                before: (new Date()).getTime(), // current time
+                before: Date.now(), // current time
                 number: parseInt(req.query.n, 10) || 100 // asks for the last 100 commits from the time specified above
             };
 

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -96,7 +96,7 @@ function ExecutorServer(options) {
         }
         query = {
             lastSeen: {
-                $lt: (new Date()).getTime() / 1000 - workerRefreshInterval / 1000 * 5
+                $lt: Date.now() / 1000 - workerRefreshInterval / 1000 * 5
             }
         };
 

--- a/src/server/storage/storage.js
+++ b/src/server/storage/storage.js
@@ -436,14 +436,13 @@ Storage.prototype.squashCommits = function (data, callback) {
                     root: rootHash,
                     parents: [fromCommit],
                     updater: [data.username],
-                    time: (new Date()).getTime(),
+                    time: Date.now(),
                     message: data.message || msg,
                     type: CONSTANTS.COMMIT_TYPE,
                     __v: CONSTANTS.VERSION
-                },
-                commitHash = '#' + generateKey(commitObj, self.gmeConfig);
+                };
 
-            commitObj[CONSTANTS.MONGO_ID] = commitHash;
+            commitObj[CONSTANTS.MONGO_ID] = '#' + generateKey(commitObj, self.gmeConfig);
 
             makeCommitData.commitObject = commitObj;
 

--- a/src/server/storage/userproject.js
+++ b/src/server/storage/userproject.js
@@ -69,7 +69,7 @@ function UserProject(dbProject, storage, mainLogger, gmeConfig) {
                 root: rootHash,
                 parents: parents,
                 updater: [user],
-                time: (new Date()).getTime(),
+                time: Date.now(),
                 message: msg,
                 type: CONSTANTS.COMMIT_TYPE,
                 __v: CONSTANTS.VERSION

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -659,9 +659,14 @@ describe('Meta Rules', function () {
                     var result;
                     c.core.setAttributeMeta(c.fco, 'InvalidRegexp', {
                         type: 'string',
-                        regexp: '/((?<=\\()[A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0-9\\.\\-_~:/\\?#\\[\\]@!\\$' +
-                        '&\'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+(?=\\)))|([A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z' +
-                        '0-9\\.\\-_~:/\\?#\\[\\]@!\\$&\'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+)/'
+                        // In node v8.10.0 the v8 seems to support regexps constructed from strings where the
+                        // leading and trailing forward slashes are included..
+                        //
+                        // regexp: '/((?<=\\()[A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0-9\\.\\-_~:/\\?#\\[\\]@!\\$' +
+                        // '&\'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+(?=\\)))|([A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0' +
+                        // '-9\\.\\-_~:/\\?#\\[\\]@!\\$&\'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+)/',
+
+                        regexp: '*****'
                     });
 
                     result = checkMetaConsistency(c.core, c.root);

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -385,7 +385,7 @@ describe('Meta Rules', function () {
                 expect(result.hasViolation).to.equal(true, result.message);
                 expect(result.message).to.include('Invalid regular expression');
                 ir.core.delAttributeMeta(node, 'withInvalidRegEx');
-                ir.core.delAttribute(node, 'withInvalidRegEx', 'hej');
+                ir.core.delAttribute(node, 'withInvalidRegEx');
 
                 // Make sure that other tests could broke.
                 return checkNode(ir.core, node);

--- a/test/common/core/users/metarules.spec.js
+++ b/test/common/core/users/metarules.spec.js
@@ -372,9 +372,14 @@ describe('Meta Rules', function () {
                 node = node_;
                 ir.core.setAttributeMeta(node, 'withInvalidRegEx', {
                     type: 'string',
-                    regexp: '/((?<=\\()[A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0-9\\.\\-_~:/\\?#\\[\\]@!\\$' +
-                    '&\'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+(?=\\)))|([A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0' +
-                    '-9\\.\\-_~:/\\?#\\[\\]@!\\$&\'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+)/'
+                    // In node v8.10.0 the v8 seems to support regexps constructed from strings where the
+                    // leading and trailing forward slashes are included..
+                    //
+                    // regexp: '/((?<=\\()[A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0-9\\.\\-_~:/\\?#\\[\\]@!\\$' +
+                    // '&\'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+(?=\\)))|([A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0' +
+                    // '-9\\.\\-_~:/\\?#\\[\\]@!\\$&\'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+)/',
+
+                    regexp: '*****'
                 });
 
                 ir.core.setAttribute(node, 'withInvalidRegEx', 'hej');

--- a/test/server/storage/userproject.spec.js
+++ b/test/server/storage/userproject.spec.js
@@ -113,7 +113,7 @@ describe('UserProject', function () {
     it('should makeCommit', function (done) {
         var numCommitsBefore;
 
-        project.getCommits((new Date()).getTime(), 100)
+        project.getCommits(Date.now(), 100)
             .then(function (commits) {
                 numCommitsBefore = commits.length;
                 return project.createBranch('makeCommit_name', importResult.commitHash);
@@ -124,7 +124,7 @@ describe('UserProject', function () {
                     importResult.rootHash, [], 'new commit');
             })
             .then(function () {
-                return project.getCommits((new Date()).getTime(), 100);
+                return project.getCommits(Date.now() + 100, 100);
             })
             .then(function (commits) {
                 expect(numCommitsBefore).to.equal(commits.length - 1);


### PR DESCRIPTION
Also use more efficient and readable `Date.now()` throughout code base.