### PR TITLE
Enable plugins to be required without requirejs and passed to manager as "class"

### DIFF
--- a/src/client/pluginmanager.js
+++ b/src/client/pluginmanager.js
@@ -80,7 +80,7 @@ define([
 
         /**
          * Run the plugin in the browser.
-         * @param {string} pluginId - id of plugin.
+         * @param {string|function} pluginIdOrClass - id or class for plugin.
          * @param {object} context
          * @param {object} context.managerConfig - where the plugin should execute.
          * @param {ProjectInterface} context.managerConfig.project - project (e.g. client.getProjectObject()).
@@ -92,7 +92,7 @@ define([
          * @param {object} [context.pluginConfig=%defaultForPlugin%] - specific configuration for the plugin.
          * @param {function(err, PluginResult)} callback
          */
-        this.runBrowserPlugin = function (pluginId, context, callback) {
+        this.runBrowserPlugin = function (pluginIdOrClass, context, callback) {
             var blobClient = new BlobClient({logger: logger.fork('BlobClient')}),
                 pluginManager = new PluginManagerBase(blobClient, null, mainLogger, gmeConfig);
 
@@ -105,12 +105,12 @@ define([
 
             pluginManager.projectAccess = client.getProjectAccess();
 
-            pluginManager.executePlugin(pluginId, context.pluginConfig, context.managerConfig, callback);
+            pluginManager.executePlugin(pluginIdOrClass, context.pluginConfig, context.managerConfig, callback);
         };
 
         /**
          * Run the plugin on the server inside a worker process.
-         * @param {string} pluginId - id of plugin.
+         * @param {string|function} pluginIdOrClass - id or class for plugin.
          * @param {object} context
          * @param {object} context.managerConfig - where the plugin should execute.
          * @param {ProjectInterface|string} context.managerConfig.project - project or id of project.
@@ -122,8 +122,8 @@ define([
          * @param {object} [context.pluginConfig=%defaultForPlugin%] - specific configuration for the plugin.
          * @param {function} callback
          */
-        this.runServerPlugin = function (pluginId, context, callback) {
-
+        this.runServerPlugin = function (pluginIdOrClass, context, callback) {
+            var pluginId = typeof pluginIdOrClass === 'string' ? pluginIdOrClass : pluginIdOrClass.metadata.id;
             if (context.managerConfig.project instanceof Project) {
                 context.managerConfig.project = context.managerConfig.project.projectId;
             }

--- a/src/common/Constants.js
+++ b/src/common/Constants.js
@@ -4,9 +4,17 @@
 /**
  * STRING CONSTANT DEFINITIONS USED IN BOTH CLIENT AND SERVER JAVASCRIPT
  * @author rkereskenyi / https://github.com/rkereskenyi
+ * @author pmeijer / https://github.com/pmeijer
  */
 
-define(['common/core/constants', 'common/storage/constants'], function (CORE, STORAGE) {
+
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['common/core/constants', 'common/storage/constants'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('./core/constants'), require('./storage/constants'));
+    }
+}(function (CORE, STORAGE) {
     'use strict';
     //return string constants
     return {
@@ -110,4 +118,4 @@ define(['common/core/constants', 'common/storage/constants'], function (CORE, ST
         }
 
     };
-});
+}));

--- a/src/common/core/constants.js
+++ b/src/common/core/constants.js
@@ -3,7 +3,14 @@
 /**
  * @author kecso / https://github.com/kecso
  */
-define([], function () {
+
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    }
+}(function () {
     'use strict';
     //return string constants
     return {
@@ -78,4 +85,4 @@ define([], function () {
 
         OVERLAY_SHARD_INDICATOR: 'sharded'
     };
-});
+}));

--- a/src/common/storage/constants.js
+++ b/src/common/storage/constants.js
@@ -64,8 +64,13 @@
  *   patch: [{op: 'add', path: '/atr/new', value: 'value'}]
  * }
  */
-
-define([], function () {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    }
+}(function () {
     'use strict';
 
     return {
@@ -140,4 +145,4 @@ define([], function () {
         ADD_ON_NOTIFICATION: 'ADD_ON_NOTIFICATION',
         CLIENT_STATE_NOTIFICATION: 'CLIENT_STATE_NOTIFICATION'
     };
-});
+}));

--- a/src/plugin/InterPluginResult.js
+++ b/src/plugin/InterPluginResult.js
@@ -6,7 +6,13 @@
  * @author pmeijer / https://github.com/meijer
  */
 
-define(['plugin/PluginResultBase'], function (PluginResultBase) {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['plugin/PluginResultBase'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('./PluginResultBase'));
+    }
+}(function (PluginResultBase) {
     'use strict';
 
     /**
@@ -46,4 +52,4 @@ define(['plugin/PluginResultBase'], function (PluginResultBase) {
     };
 
     return InterPluginResult;
-});
+}));

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -9,25 +9,41 @@
  * @author pmeijer / https://github.com/pmeijer
  */
 
-define([
-    'q',
-    'plugin/PluginConfig',
-    'plugin/PluginResultBase',
-    'plugin/PluginResult',
-    'plugin/InterPluginResult',
-    'plugin/PluginMessage',
-    'plugin/PluginNodeDescription',
-    'plugin/util',
-    'common/storage/constants'
-], function (Q,
-             PluginConfig,
-             PluginResultBase,
-             PluginResult,
-             InterPluginResult,
-             PluginMessage,
-             PluginNodeDescription,
-             pluginUtil,
-             STORAGE_CONSTANTS) {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([
+            'q',
+            'plugin/PluginConfig',
+            'plugin/PluginResultBase',
+            'plugin/PluginResult',
+            'plugin/InterPluginResult',
+            'plugin/PluginMessage',
+            'plugin/PluginNodeDescription',
+            'plugin/util',
+            'common/storage/constants'
+        ], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(
+            require('q'),
+            require('./PluginConfig'),
+            require('./PluginResultBase'),
+            require('./PluginResult'),
+            require('./InterPluginResult'),
+            require('./PluginMessage'),
+            require('./PluginNodeDescription'),
+            require('./util'),
+            require('../common/storage/constants')
+        );
+    }
+}(function (Q,
+            PluginConfig,
+            PluginResultBase,
+            PluginResult,
+            InterPluginResult,
+            PluginMessage,
+            PluginNodeDescription,
+            pluginUtil,
+            STORAGE_CONSTANTS) {
     'use strict';
 
     /**
@@ -890,4 +906,4 @@ define([
     //</editor-fold>
 
     return PluginBase;
-});
+}));

--- a/src/plugin/PluginConfig.js
+++ b/src/plugin/PluginConfig.js
@@ -5,7 +5,13 @@
  * @author lattmann / https://github.com/lattmann
  */
 
-define([], function () {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    }
+}(function () {
     'use strict';
     /**
      * Initializes a new instance of plugin configuration.
@@ -45,4 +51,4 @@ define([], function () {
 
 
     return PluginConfig;
-});
+}));

--- a/src/plugin/PluginManagerConfiguration.js
+++ b/src/plugin/PluginManagerConfiguration.js
@@ -6,7 +6,13 @@
  */
 
 
-define([], function () {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    }
+}(function () {
     'use strict';
     /**
      * Initializes a new instance of plugin manager configuration.
@@ -56,4 +62,4 @@ define([], function () {
     };
 
     return PluginManagerConfiguration;
-});
+}));

--- a/src/plugin/PluginMessage.js
+++ b/src/plugin/PluginMessage.js
@@ -8,7 +8,13 @@
  */
 
 
-define(['plugin/PluginNodeDescription'], function (PluginNodeDescription) {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['plugin/PluginNodeDescription'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('./PluginNodeDescription'));
+    }
+}(function (PluginNodeDescription) {
     'use strict';
 
     /**
@@ -60,4 +66,4 @@ define(['plugin/PluginNodeDescription'], function (PluginNodeDescription) {
     };
 
     return PluginMessage;
-});
+}));

--- a/src/plugin/PluginNodeDescription.js
+++ b/src/plugin/PluginNodeDescription.js
@@ -8,7 +8,13 @@
  */
 
 
-define([], function () {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    }
+}(function () {
     'use strict';
     /**
      * Initializes a new instance of plugin node description object.
@@ -52,4 +58,4 @@ define([], function () {
     };
 
     return PluginNodeDescription;
-});
+}));

--- a/src/plugin/PluginResult.js
+++ b/src/plugin/PluginResult.js
@@ -7,7 +7,13 @@
  * @author lattmann / https://github.com/lattmann
  */
 
-define(['plugin/PluginMessage', 'plugin/PluginResultBase'], function (PluginMessage, PluginResultBase) {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['plugin/PluginMessage', 'plugin/PluginResultBase'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('./PluginMessage'), require('./PluginResultBase'));
+    }
+}(function (PluginMessage, PluginResultBase) {
     'use strict';
 
     /**
@@ -188,4 +194,4 @@ define(['plugin/PluginMessage', 'plugin/PluginResultBase'], function (PluginMess
     };
 
     return PluginResult;
-});
+}));

--- a/src/plugin/PluginResultBase.js
+++ b/src/plugin/PluginResultBase.js
@@ -6,7 +6,13 @@
  * @author pmeijer / https://github.com/meijer
  */
 
-define([], function () {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    }
+}(function () {
     'use strict';
 
     /**
@@ -86,4 +92,4 @@ define([], function () {
     };
 
     return PluginResultBase;
-});
+}));

--- a/src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample.js
+++ b/src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample.js
@@ -7,14 +7,25 @@
  * @module CorePlugins:MinimalWorkingExample
  */
 
-define([
-    'plugin/PluginConfig',
-    'plugin/PluginBase',
-    'text!./metadata.json'
-], function (PluginConfig, PluginBase, pluginMetadata) {
+
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([
+            'plugin/PluginConfig',
+            'plugin/PluginBase',
+            'text!./metadata.json'
+        ], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(
+            require('../../PluginConfig'),
+            require('../../PluginBase'),
+            require('./metadata.json')
+        );
+    }
+}(function (PluginConfig, PluginBase, pluginMetadata) {
     'use strict';
 
-    pluginMetadata = JSON.parse(pluginMetadata);
+    pluginMetadata = typeof pluginMetadata === 'string' ? JSON.parse(pluginMetadata) : pluginMetadata;
 
     /**
      * Initializes a new instance of MinimalWorkingExample.
@@ -98,4 +109,4 @@ define([
     };
 
     return MinimalWorkingExample;
-});
+}));

--- a/src/plugin/managerbase.js
+++ b/src/plugin/managerbase.js
@@ -38,10 +38,14 @@ define([
         this.logger = mainLogger.fork('PluginManagerBase');
         this.notificationHandlers = [];
 
-        function getPluginInstance(pluginId, callback) {
+        function getPluginInstance(pluginIdOrClass, callback) {
+            if (typeof pluginIdOrClass === 'function') {
+                return Q(pluginIdOrClass);
+            }
+
             var deferred = Q.defer(),
                 rejected = false,
-                pluginPath = 'plugin/' + pluginId + '/' + pluginId + '/' + pluginId;
+                pluginPath = 'plugin/' + pluginIdOrClass + '/' + pluginIdOrClass + '/' + pluginIdOrClass;
 
             if (rejected === false) {
                 requirejs([pluginPath],
@@ -49,9 +53,9 @@ define([
                         var plugin = new PluginClass();
                         self.logger.debug('requirejs plugin from path: ' + pluginPath);
                         if (self.serverSide && plugin.pluginMetadata.disableServerSideExecution) {
-                            deferred.reject(new Error(pluginId + ' cannot be invoked on server.'));
+                            deferred.reject(new Error(pluginIdOrClass + ' cannot be invoked on server.'));
                         } else if (self.browserSide && plugin.pluginMetadata.disableBrowserSideExecution) {
-                            deferred.reject(new Error(pluginId + ' cannot be invoked in browser.'));
+                            deferred.reject(new Error(pluginIdOrClass + ' cannot be invoked in browser.'));
                         } else {
                             deferred.resolve(plugin);
                         }
@@ -104,7 +108,7 @@ define([
 
         /**
          *
-         * @param {string} pluginId
+         * @param {string} pluginIdOrClass
          * @param {object} pluginConfig - configuration for the plugin.
          * @param {object} context
          * @param {string} [context.branchName] - name of branch that should be updated
@@ -115,9 +119,11 @@ define([
          * @param {string} [context.namespace=''] - used namespace during execution ('' represents all namespaces).
          * @param {function} callback
          */
-        this.executePlugin = function (pluginId, pluginConfig, context, callback) {
-            var plugin;
-            self.initializePlugin(pluginId)
+        this.executePlugin = function (pluginIdOrClass, pluginConfig, context, callback) {
+            var pluginId = typeof pluginIdOrClass === 'string' ? pluginIdOrClass : pluginIdOrClass.metadata.id,
+                plugin;
+
+            self.initializePlugin(pluginIdOrClass)
                 .then(function (plugin_) {
                     plugin = plugin_;
                     return self.configurePlugin(plugin, pluginConfig, context);

--- a/src/plugin/util.js
+++ b/src/plugin/util.js
@@ -5,7 +5,13 @@
  * @author pmeijer / https://github.com/pmeijer
  */
 
-define(['q'], function (Q) {
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['q'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('q'));
+    }
+}(function (Q) {
     'use strict';
 
     /**
@@ -114,4 +120,4 @@ define(['q'], function (Q) {
     return {
         loadNodesAtCommitHash: loadNodesAtCommitHash
     };
-});
+}));

--- a/test/plugin/nodemanagerbase.spec.js
+++ b/test/plugin/nodemanagerbase.spec.js
@@ -226,6 +226,25 @@ describe('climanager', function () {
         });
     });
 
+    it('should executePlugin when passing in Plugin Class (required with common-js)', function (done) {
+        var manager = new PluginCliManager(null, logger, gmeConfig),
+            pluginConfig = {
+                save: false
+            },
+            context = {
+                project: project,
+                commitHash: commitHash,
+                branchName: branchName
+            },
+            PluginClass = require('../../src/plugin/coreplugins/MinimalWorkingExample/MinimalWorkingExample');
+
+        manager.executePlugin(PluginClass, pluginConfig, context, function (err, pluginResult) {
+            expect(err).to.equal(null);
+            expect(pluginResult.success).to.equal(true);
+            done();
+        });
+    });
+
     it('should executePlugin without specified commitHash', function (done) {
         var manager = new PluginCliManager(null, logger, gmeConfig),
             pluginConfig = {


### PR DESCRIPTION
The main use-case for this is to enable browser side execution of plugins when from an app specific build (with e.g. webpack) bundling the plugins and using `webgme.build.classes.js` to access the client.

This approach enables bundling the files without relying on requirejs (and replicating the configuration in webgme). In the future all common, plugin, client, etc. files should probably be converted to support commonJS (node "require") as well. If so, the entire client API could be made part of the bundle as well and the `webgme.build.classes.js` wouldn't have to be used.