### PR TITLE
Fixes #60 Cascading moves cause crash during merge

### DIFF
--- a/src/common/core/corediff.js
+++ b/src/common/core/corediff.js
@@ -975,7 +975,7 @@ define([
 
             if (diff.removed === false || typeof diff.movedFrom === 'string') {
                 // this is a new node at the given place, so let's check for base collisions
-                if (checkContainer(getParentGuid(diffBase, path), CONSTANTS.PATH_SEP + getRelidFromPath(path), false)) {
+                if (checkContainer(getParentGuid(diffBase, path), CONSTANTS.PATH_SEP + getRelidFromPath(path))) {
                     // we have to move the node
                     if (moveBase === true) {
                         dst2src = _concatMoves.getBaseSourceFromDestination;

--- a/test/common/core/corediff.scenarios.spec.js
+++ b/test/common/core/corediff.scenarios.spec.js
@@ -924,6 +924,7 @@ describe('corediff scenarios', function () {
                 var merge = core.tryToConcatChanges(diffs[0], diffs[1]);
 
                 expect(merge.items).to.have.length(0);
+                expect(merge.merge.r2.r1).to.include.key('r0');
             })
             .nodeify(done);
     });
@@ -970,6 +971,7 @@ describe('corediff scenarios', function () {
             .then(function (diffs) {
                 var merge = core.tryToConcatChanges(diffs[0], diffs[1]);
                 expect(merge.items).to.have.length(0);
+                expect(merge.merge.i).not.to.include.key('c');
             })
             .nodeify(done);
     });

--- a/test/common/core/corediff.scenarios.spec.js
+++ b/test/common/core/corediff.scenarios.spec.js
@@ -925,9 +925,17 @@ describe('corediff scenarios', function () {
 
                 expect(merge.items).to.have.length(0);
                 expect(merge.merge.r2.r1).to.include.key('r0');
+
+                // check both directions
+                merge = core.tryToConcatChanges(diffs[1], diffs[0]);
+
+                expect(merge.items).to.have.length(0);
+                expect(merge.merge.r2.r1).to.include.key('r0');
             })
             .nodeify(done);
     });
+
+
 
     // Complex inheritance collisions
     it('should be able to merge multiple colliding creations', function (done) {
@@ -970,6 +978,11 @@ describe('corediff scenarios', function () {
             })
             .then(function (diffs) {
                 var merge = core.tryToConcatChanges(diffs[0], diffs[1]);
+                expect(merge.items).to.have.length(0);
+                expect(merge.merge.i).not.to.include.key('c');
+
+                // check both directions
+                merge = core.tryToConcatChanges(diffs[1], diffs[0]);
                 expect(merge.items).to.have.length(0);
                 expect(merge.merge.i).not.to.include.key('c');
             })


### PR DESCRIPTION
When traversing over the containers of a new/moved node for potential inheritance relid collision, the recursion should always follow a single branch and not jump among both.