### PR TITLE
Initiate graceful server shutdown on SIGTERM

### DIFF
--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -45,7 +45,7 @@ var path = require('path'),
 
     mainLogger;
 
-process.on('SIGINT', function () {
+function shutdown() {
     var i,
         error = false,
         numStops = 0;
@@ -87,7 +87,10 @@ process.on('SIGINT', function () {
     if (numStops === 0) {
         exit(0);
     }
-});
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
 
 function StandAloneServer(gmeConfig) {
     var self = this,


### PR DESCRIPTION
Before it was only listening to `SIGINT` (that is when a user interrupts by e.g. hitting Ctrl+C).

Both systemd and docker sends `SIGTERM` signals and waits for a configurable grace period before killing (`SIGKILL`) the process.