### PR TITLE
Fixes #73 Containment inheritance loop detection during node creation is missing

### DIFF
--- a/src/client/gmeNodeGetter.js
+++ b/src/client/gmeNodeGetter.js
@@ -93,6 +93,22 @@ define([], function () {
         }
     };
 
+    GMENode.prototype.isValidNewChild = function (basePath) {
+        var base;
+        if (typeof basePath === 'string') {
+            base = _getNode(this._state.nodes, basePath);
+            if (base) {
+                return this._state.core.isValidNewChild(this._state.nodes[this._id].node, base);
+            } else {
+                return false;
+            }
+        } else if (basePath === undefined || basePath === null) {
+            return true;
+        }
+
+        return false;
+    };
+
     GMENode.prototype.getInheritorIds = function () {
         return this._state.core.getInstancePaths(this._state.nodes[this._id].node);
     };

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -4470,6 +4470,30 @@ define([
 
             return core.getValidTargetPaths(node, name);
         };
+
+        /**
+         * Checks if a node of the given type can be created under the parent. It does not check for meta consistency.
+         * It only validates if the proposed creation would cause any loops in the combined containment
+         * inheritance trees.
+         * @param {module:Core~Node | null } parentNode - the parent in question.
+         * @param {module:Core~Node | null } baseNode - the intended type of the node.
+         *
+         * @return {boolean} True if a child of the type can be created.
+         *
+         * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         */
+        this.isValidNewChild = function (parentNode, baseNode) {
+            if (parentNode !== null) {
+                ensureNode(parentNode, 'parentNode');
+            }
+
+            if (baseNode !== null) {
+                ensureNode(baseNode, 'baseNode');
+            }
+
+            return core.isValidNewChild(parentNode, baseNode);
+        };
     }
 
     return Core;

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -803,7 +803,7 @@ define([
 
         /**
          * Creates a node according to the given parameters.
-         * @param {object} parameters - the details of the creation.
+         * @param {object} [parameters] - the details of the creation.
          * @param {module:Core~Node | null} [parameters.parent] - the parent of the node to be created.
          * @param {module:Core~Node | null} [parameters.base] - the base of the node to be created.
          * @param {string} [parameters.relid] - the relative id of the node to be created (if reserved, the function
@@ -4481,9 +4481,9 @@ define([
         };
 
         /**
-         * Checks if a node of the given type can be created under the parent. It does not check for meta consistency.
-         * It only validates if the proposed creation would cause any loops in the combined containment
-         * inheritance trees.
+         * Checks if an instance of the given base can be created under the parent. It does not check for
+         * meta consistency. It only validates if the proposed creation would cause any loops in the
+         * combined containment inheritance trees.
          * @param {module:Core~Node | null } parentNode - the parent in question.
          * @param {module:Core~Node | null } baseNode - the intended type of the node.
          *

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -832,6 +832,15 @@ define([
                 if (parameters.hasOwnProperty('guid') && parameters.guid !== undefined) {
                     ensureGuid(parameters.guid, 'parameters.guid');
                 }
+
+                if (parameters.hasOwnProperty('parent') &&
+                    parameters.parent !== null && parameters.parent !== undefined &&
+                    parameters.hasOwnProperty('base') &&
+                    parameters.base !== null && parameters.base !== undefined &&
+                    core.isValidNewChild(parameters.parent, parameters.base) === false) {
+                    throw new CoreIllegalOperationError('Not allowed to create node that would cause loop in the ' +
+                        'combined containment inheritance graph.');
+                }
             }
             return core.createNode(parameters);
         };

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -832,15 +832,6 @@ define([
                 if (parameters.hasOwnProperty('guid') && parameters.guid !== undefined) {
                     ensureGuid(parameters.guid, 'parameters.guid');
                 }
-
-                if (parameters.hasOwnProperty('parent') &&
-                    parameters.parent !== null && parameters.parent !== undefined &&
-                    parameters.hasOwnProperty('base') &&
-                    parameters.base !== null && parameters.base !== undefined &&
-                    core.isValidNewChild(parameters.parent, parameters.base) === false) {
-                    throw new CoreIllegalOperationError('Not allowed to create node that would cause loop in the ' +
-                        'combined containment inheritance graph.');
-                }
             }
             return core.createNode(parameters);
         };

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -762,6 +762,27 @@ define([
             return node;
         };
 
+        this.isValidNewChild = function (parentNode, baseNode) {
+            ASSERT(!parentNode || self.isValidNode(parentNode));
+            ASSERT(!baseNode || self.isValidNode(baseNode));
+            // When we look for a loop, we see relationship parent and instance as edges
+            // The intended new node would make a path base->parent, if the node would cause a loop,
+            // then there should already be a path parent->base
+
+            if (!parentNode || !baseNode) {
+                return true;
+            }
+
+            while (parentNode) {
+                if (self.isInstanceOf(baseNode, parentNode)) {
+                    return false;
+                }
+                parentNode = self.getParent(parentNode);
+            }
+
+            return true;
+        };
+
         this.isValidNewParent = function (node, parent) {
             ASSERT(self.isValidNode(node) && self.isValidNode(parent));
             var visited = {

--- a/src/common/core/coretype.js
+++ b/src/common/core/coretype.js
@@ -838,31 +838,32 @@ define([
         };
 
         this.copyNode = function (node, parent, relidLength) {
-            var newnode;
+            var newNode,
+                base = self.getBase(node);
 
-            if (self.isValidNewChild(parent, self.getBase(node)) === false) {
+            if (base !== null && self.isValidNewChild(parent, base) === false) {
                 throw new CoreIllegalOperationError('Not allowed to copy the node under a parent that would ' +
                     'cause loop in the combined containment inheritance graph.');
             }
 
             relidLength = relidLength || innerCore.getProperty(parent, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
-            newnode = innerCore.copyNode(node, parent, self.getChildrenRelids(parent, true), relidLength);
-            newnode.base = node.base;
+            newNode = innerCore.copyNode(node, parent, self.getChildrenRelids(parent, true), relidLength);
+            newNode.base = node.base;
             if (typeof self.getPointerPath(node, CONSTANTS.BASE_POINTER) === 'string') {
-                innerCore.setPointer(newnode, CONSTANTS.BASE_POINTER, node.base);
+                innerCore.setPointer(newNode, CONSTANTS.BASE_POINTER, node.base);
             }
 
             // The copy does not have any instances at this point -> reset the property.
-            innerCore.deleteProperty(newnode, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
+            innerCore.deleteProperty(newNode, CONSTANTS.MINIMAL_RELID_LENGTH_PROPERTY);
 
-            this.processRelidReservation(parent, this.getRelid(newnode));
+            this.processRelidReservation(parent, this.getRelid(newNode));
 
             // Addition to #1232
             if (isInheritedChild(parent)) {
                 self.processRelidReservation(self.getParent(parent), self.getRelid(parent));
             }
 
-            return newnode;
+            return newNode;
         };
 
         this.copyNodes = function (nodes, parent, relidLength) {
@@ -1214,7 +1215,7 @@ define([
             if (self.isValidNewBase(node, base) === false) {
                 throw new CoreIllegalOperationError('New base would create loop in containment/inheritance tree.');
             }
-            
+
             if (base) {
                 //TODO maybe this is not the best way, needs to be double checked
                 var parent = self.getParent(node),

--- a/src/docs/client.getter.doc.js
+++ b/src/docs/client.getter.doc.js
@@ -300,6 +300,26 @@
  * @return {bool} Returns true if the base is on the inheritance chain of node. A node is considered to be an 
  * instance of itself here.
  */
+
+/**
+ * @description Checks if the node can have a child of the given type without causing containment inheritance loop.
+ * @function isValidNewChild
+ * @memberOf GMENode
+ * @instance
+ * @param {string} baseId - Id to the base node that would be the type of the child.
+ *
+ * @return {bool} Returns true if a child of the given type can be created.
+ */
+
+/**
+ * @description Checks if base can be the new base of node.
+ * @function isValidNewBase
+ * @memberOf GMENode
+ * @param {string | null | undefined} base - the new base.
+ *
+ * @return {boolean} True if the supplied base is a valid base for the node.
+ */
+
 // expect(typeof node.getRegistryNames).to.equal('function');
 // expect(typeof node.getOwnRegistryNames).to.equal('function');
 // expect(typeof node.getMemberIds).to.equal('function');

--- a/test/client/js/client/gmeNodeGetter.spec.js
+++ b/test/client/js/client/gmeNodeGetter.spec.js
@@ -100,6 +100,7 @@ describe('gmeNodeGetter', function () {
         expect(typeof node.getBaseId).to.equal('function');
         expect(typeof node.isValidNewBase).to.equal('function');
         expect(typeof node.isValidNewParent).to.equal('function');
+        expect(typeof node.isValidNewChild).to.equal('function');
         expect(typeof node.getInheritorIds).to.equal('function');
         expect(typeof node.getAttribute).to.equal('function');
         expect(typeof node.getOwnAttribute).to.equal('function');
@@ -271,6 +272,15 @@ describe('gmeNodeGetter', function () {
         expect(node.isValidNewParent(null)).to.equal(false);
         expect(node.isValidNewParent('/1')).to.equal(false);
         expect(node.isValidNewParent('unknown')).to.equal(false);
+    });
+
+    it('should return whether a new child of a given type could be created under the parent', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode);
+
+        expect(node.isValidNewChild(null)).to.equal(true);
+        expect(node.isValidNewChild('/1')).to.equal(true);
+        expect(node.isValidNewChild('/175547009/871430202')).to.equal(false);
+        expect(node.isValidNewChild({})).to.equal(false);
     });
 
     it('should return the paths of instance', function () {

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -127,7 +127,7 @@ describe('core', function () {
                 'getChildDefinitionInfo', 'getValidTargetPaths', 'getOwnValidTargetPaths',
                 'isValidAspectMemberOf', 'moveAspectMetaTarget', 'movePointerMetaTarget',
                 'renameAttributeMeta', 'moveMember', 'getOwnValidPointerNames', 'getOwnValidSetNames',
-                'getValidAspectTargetPaths', 'getOwnValidAspectTargetPaths'
+                'getValidAspectTargetPaths', 'getOwnValidAspectTargetPaths', 'isValidNewChild'
             ];
 
         //console.log(_.difference(functions, Matches));
@@ -4942,6 +4942,28 @@ describe('core', function () {
             myError = e;
         } finally {
             expect(myError.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should throw @isValidNewChild if parameters are bad', function () {
+        var myError;
+
+        try {
+            core.isValidNewChild('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+
+        try {
+            core.isValidNewChild(rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
         }
     });
 

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -542,6 +542,15 @@ describe('core', function () {
             expect(myError.name).to.eql('CoreIllegalArgumentError');
             myError = null;
         }
+
+        try {
+            core.createNode({parent: rootNode, base: rootNode});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalOperationError');
+            myError = null;
+        }
     });
 
     it('should throw @deleteNode if not valid node is given', function () {

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -735,6 +735,26 @@ describe('coretype', function () {
         }, core.loadChildren(node, '/n'));
     });
 
+    // Child
+    it('isValidNewChild should return true if no potential loop', function () {
+        var fco = core.createNode({parent: root});
+
+        expect(core.isValidNewChild(null, root)).to.equal(true);
+        expect(core.isValidNewChild(root, null)).to.equal(true);
+        expect(core.isValidNewChild(root, fco)).to.equal(true);
+    });
+
+    it('isValidNewChild should return false if potential loop is found', function () {
+        var fco = core.createNode({parent: root, relid: 'FCO'}),
+            container = core.createNode({parent: root, base: fco, relid: 'C'}),
+            element = core.createNode({parent: root, base: fco, relid: 'E'}),
+            model = core.createNode({parent: root, base: container, relid: 'M'}),
+            node = core.createNode({parent: model, base: element, relid: 'N'});
+
+        expect(core.isValidNewChild(node, fco)).to.equal(true);
+        expect(core.isValidNewChild(fco, node)).to.equal(false);
+    });
+
     it('new node should have relidLength when createNode with relidLength', function () {
         var newNode = core.createNode({parent: root}, 7);
         expect(core.getRelid(newNode)).to.have.length(7);

--- a/test/common/core/coretype.spec.js
+++ b/test/common/core/coretype.spec.js
@@ -1553,4 +1553,69 @@ describe('coretype', function () {
         expect(core.getPointerNames(copiedNodes[0])).to.have.members(['base', 'ref']);
         expect(core.getPointerPath(copiedNodes[0], 'ref')).to.eql(core.getPath(copiedNodes[1]));
     });
+
+    // causing loops during operations
+    it('should createNode throw if it would cause inheritance containment loop', function () {
+        var root = core.createNode(),
+            base = core.createNode({parent: root});
+
+        try {
+            core.createNode({parent: base, base: base});
+            expect(true).to.equal(false);
+        } catch (e) {
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should copyNode throw if it would cause inheritance containment loop', function () {
+        var root = core.createNode(),
+            base = core.createNode({parent: root}),
+            instance = core.createNode({parent: root, base: base});
+
+        try {
+            core.copyNode(instance, base);
+            expect(true).to.equal(false);
+        } catch (e) {
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should copyNodes throw if it would cause inheritance containment loop', function () {
+        var root = core.createNode(),
+            base = core.createNode({parent: root}),
+            instance = core.createNode({parent: root, base: base});
+
+        try {
+            core.copyNodes([instance], base);
+            expect(true).to.equal(false);
+        } catch (e) {
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should moveNode throw if it would cause inheritance containment loop', function () {
+        var root = core.createNode(),
+            base = core.createNode({parent: root}),
+            instance = core.createNode({parent: root, base: base});
+
+        try {
+            core.moveNode(instance, base);
+            expect(true).to.equal(false);
+        } catch (e) {
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+    });
+
+    it('should setBase throw if it would cause inheritance containment loop', function () {
+        var root = core.createNode(),
+            base = core.createNode({parent: root}),
+            other = core.createNode({parent: base});
+
+        try {
+            core.setBase(other, base);
+            expect(true).to.equal(false);
+        } catch (e) {
+            expect(e.name).to.eql('CoreIllegalOperationError');
+        }
+    });
 });


### PR DESCRIPTION
Closes webgme/webgme#1585 as well.
New functions
Core.isValidNewChild
GMENode.isValidNewChild

Also, to fix the unexpected throw behavior in webgme, the createNode runs this check as a precaution.