### PR TITLE
Closes #78 Add support to specify seeds to be created at server start up

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -148,7 +148,8 @@ var path = require('path'),
             enable: true,
             allowDuplication: true, //requires mongodb >= 2.6
             defaultProject: 'EmptyProject',
-            basePaths: [path.join(__dirname, '../seeds')]
+            basePaths: [path.join(__dirname, '../seeds')],
+            createAtStartup: []
         },
 
         server: {

--- a/config/validator.js
+++ b/config/validator.js
@@ -231,6 +231,23 @@ function validateConfig(configOrFileName) {
     assertBoolean('config.seedProjects.enable', config.seedProjects.enable);
     assertString('config.seedProjects.defaultProject', config.seedProjects.defaultProject);
     assertArray('config.seedProjects.basePaths', config.seedProjects.basePaths);
+    assertArray('config.seedProjects.createAtStartup', config.seedProjects.createAtStartup);
+    config.seedProjects.createAtStartup.forEach(function (seedInfo, index) {
+        assertObject('config.seedProjects.createAtStartup[' + index + ']', config.seedProjects.createAtStartup[index]);
+        assertString('config.seedProjects.createAtStartup[' + index + '].seedId',
+            config.seedProjects.createAtStartup[index].seedId);
+        assertString('config.seedProjects.createAtStartup[' + index + '].projectName', seedInfo.projectName);
+        assertObject('config.seedProjects.createAtStartup[' + index + '].rights', seedInfo.rights);
+        if (seedInfo.creatorId) {
+            assertString('config.seedProjects.createAtStartup[' + index + '].creatorId', seedInfo.creatorId);
+        } else if (typeof config.authentication.adminAccount !== 'string') {
+            throw new Error('Either config.seedProjects.createAtStartup[' + index +
+                '].creatorId or config.authentication.adminAccount should exists!');
+        }
+        if (seedInfo.ownerId) {
+            assertString('config.seedProjects.createAtStartup[' + index + '].ownerId', seedInfo.ownerId);
+        }
+    });
 
     // server configuration
     expectedKeys.push('server');

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var requirejs = require('requirejs'),
     path = require('path'),
     requireJsBase = path.join(__dirname, 'src'),
     fs = require('fs'),
-    webgmeUtils = require('./src/utils'),
+    webgmeUtils,
     _core,
     _canon,
     _Logger,
@@ -35,6 +35,8 @@ requirejs.config({
         executor: 'common/executor'
     }
 });
+
+webgmeUtils = require('./src/utils');
 
 function addToRequireJsPaths(gmeConfig) {
 

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -225,6 +225,9 @@ function StandAloneServer(gmeConfig) {
                 return Q.all(promises);
             })
             .then(function () {
+                return webgmeUtils.createStartUpProjects(gmeConfig, __gmeAuth, __storage, logger);
+            })
+            .then(function () {
                 var promises = [];
                 __webSocket.start(__httpServer);
 

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -225,9 +225,6 @@ function StandAloneServer(gmeConfig) {
                 return Q.all(promises);
             })
             .then(function () {
-                return webgmeUtils.createStartUpProjects(gmeConfig, __gmeAuth, __storage, logger);
-            })
-            .then(function () {
                 var promises = [];
                 __webSocket.start(__httpServer);
 
@@ -247,6 +244,9 @@ function StandAloneServer(gmeConfig) {
                 });
 
                 return serverDeferred.promise;
+            })
+            .then(function () {
+                return webgmeUtils.createStartUpProjects(gmeConfig, __gmeAuth, __storage, logger, getUrl());
             })
             .nodeify(function (err) {
                 self.isRunning = true;

--- a/src/utils.js
+++ b/src/utils.js
@@ -496,6 +496,8 @@ function createStartUpProjects(gmeConfig, gmeAuth, storage, logger, url) {
                 if (projectInfo.failed) {
                     return;
                 }
+                logger.info('Creating \'' + projectInfo.projectName + '\' for \'' + projectInfo.ownerId +
+                    '\' from seed[' + projectInfo.seedId + '].');
                 promises.push(Q.ninvoke(worker, 'seedProject', webTokens[index], projectInfo.projectName,
                     projectInfo.ownerId, {seedName: projectInfo.seedId, type: 'file'}));
             });
@@ -517,6 +519,8 @@ function createStartUpProjects(gmeConfig, gmeAuth, storage, logger, url) {
                 }
 
                 for (userOrOrg in projectInfo.rights) {
+                    logger.info('Authorizing \'' + userOrOrg + '\' to use \'' + projectInfo.projectName +
+                        '\' of \'' + projectInfo.ownerId + '.');
                     authorizationRequests.push(gmeAuth.authorizer.setAccessRights(userOrOrg,
                         id, projectInfo.rights[userOrOrg], projectAuthParams));
                 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -466,7 +466,6 @@ function createStartUpProjects(gmeConfig, gmeAuth, storage, logger, url) {
                     id = storageUtils.getProjectIdFromOwnerIdAndProjectName(projectInfo.ownerId,
                         projectInfo.projectName);
 
-                console.log(projectLists[index], id);
                 if (isProjectExists(id, projectLists[index]) === false) {
                     createdProjects.push(projectInfo);
                     logger.info('Creating \'' + projectInfo.projectName + '\' for \'' + projectInfo.ownerId +

--- a/src/utils.js
+++ b/src/utils.js
@@ -425,7 +425,17 @@ function createStartUpProjects(gmeConfig, gmeAuth, storage, logger, url) {
         promises = [],
         creators = [],
         tokens = [],
-        createdProjects = [];
+        createdProjects = [],
+        isProjectExists = function (projectId, list) {
+            var exists = false;
+
+            list.forEach(function (projectInfo) {
+                if (projectInfo._id === projectId) {
+                    exists = true;
+                }
+            });
+            return exists;
+        };
 
 
     configArray.forEach(function (projectInfo) {
@@ -444,7 +454,7 @@ function createStartUpProjects(gmeConfig, gmeAuth, storage, logger, url) {
 
             tokens = tokens_;
             creators.forEach(function (owner) {
-                promises.push(storage.getProjects({user: owner}));
+                promises.push(storage.getProjects({username: owner}));
             });
 
             return Q.all(promises);
@@ -456,7 +466,8 @@ function createStartUpProjects(gmeConfig, gmeAuth, storage, logger, url) {
                     id = storageUtils.getProjectIdFromOwnerIdAndProjectName(projectInfo.ownerId,
                         projectInfo.projectName);
 
-                if (projectLists[index].indexOf(id) === -1) {
+                console.log(projectLists[index], id);
+                if (isProjectExists(id, projectLists[index]) === false) {
                     createdProjects.push(projectInfo);
                     logger.info('Creating \'' + projectInfo.projectName + '\' for \'' + projectInfo.ownerId +
                         '\' from seed[' + projectInfo.seedId + '].');

--- a/test/config/config.spec.js
+++ b/test/config/config.spec.js
@@ -128,6 +128,55 @@ describe('configuration and components', function () {
         }
     });
 
+    it('should throw if projectSeeds.createAtStartup is malformed',
+        function () {
+            var config;
+            process.env.NODE_ENV = 'test';
+            config = require('../../config');
+            unloadConfigs();
+            validateConfig = require('../../config/validator').validateConfig;
+
+            (function () {
+                var myConf = JSON.parse(JSON.stringify(config));
+                myConf.seedProjects.createAtStartup = [{seedId: 'EmptyProjecct', projectName: 'One', rights: {}}];
+                validateConfig(myConf);
+            }).should.throw(Error);
+            (function () {
+                var myConf = JSON.parse(JSON.stringify(config));
+                myConf.seedProjects.createAtStartup = 'fault';
+                validateConfig(myConf);
+            }).should.throw(Error);
+
+            (function () {
+                var myConf = JSON.parse(JSON.stringify(config));
+                myConf.seedProjects.createAtStartup = [{projectName: 'One', ownerId: 'admin', rights: {}}];
+                validateConfig(myConf);
+            }).should.throw(Error);
+
+            (function () {
+                var myConf = JSON.parse(JSON.stringify(config));
+                myConf.seedProjects.createAtStartup = [{
+                    seedId: 'EmptyProjecct',
+                    projectName: 'One',
+                    creatorId: 'admin',
+                    rights: {}
+                }];
+                validateConfig(myConf);
+            }).should.not.throw(Error);
+
+            (function () {
+                var myConf = JSON.parse(JSON.stringify(config));
+                myConf.authentication.adminAccount = 'admin';
+                myConf.seedProjects.createAtStartup = [{
+                    seedId: 'EmptyProjecct',
+                    projectName: 'One',
+                    rights: {}
+                }];
+                validateConfig(myConf);
+            }).should.not.throw(Error);
+        }
+    );
+
     it('clientconfig should not expose mongo', function () {
         var config,
             clientConfig;

--- a/test/server/standalone.auth.spec.js
+++ b/test/server/standalone.auth.spec.js
@@ -124,7 +124,6 @@ describe('standalone http server with authentication turned on', function () {
         });
     });
 
-
     it('should log in', function (done) {
         logIn(function (err) {
             if (err) {
@@ -196,7 +195,6 @@ describe('standalone http server with authentication turned on', function () {
             });
     });
 
-
     it('should be able to export an authorized project /worker/simpleResult/:id/exported_branch', function (done) {
         var projectName = 'project',
             projectId = testFixture.projectName2Id(projectName),
@@ -245,7 +243,6 @@ describe('standalone http server with authentication turned on', function () {
             })
             .nodeify(done);
     });
-
 
     it('should return a readable error', function (done) {
         var projectName = 'DoesntExist';

--- a/test/server/standalone.startup.spec.js
+++ b/test/server/standalone.startup.spec.js
@@ -1,0 +1,255 @@
+/*eslint-env node, mocha*/
+/**
+ * @author pmeijer / https://github.com/pmeijer
+ */
+
+describe.only('standalone startup with authentication turned on', function () {
+    'use strict';
+    var testFixture = require('../_globals.js'),
+        WebGME = testFixture.WebGME,
+        safeStorage,
+        webgmeToken,
+        gmeAuth,
+        expect = testFixture.expect,
+        should = testFixture.should,
+        superagent = testFixture.superagent,
+        Q = testFixture.Q,
+        logger,
+        agent,
+        server,
+        gmeConfig,
+        authorizer,
+        projectAuthParams,
+        logIn = function (callback) {
+            testFixture.logIn(server, agent, 'user', 'plaintext').nodeify(callback);
+        },
+        openSocketIo = function (callback) {
+            return testFixture.openSocketIo(server, agent, 'user', 'plaintext')
+                .then(function (result) {
+                    webgmeToken = result.webgmeToken;
+                    return result.socket;
+                })
+                .nodeify(callback);
+        };
+
+    beforeEach(function (done) {
+        agent = superagent.agent();
+        testFixture.clearDBAndGetGMEAuth(gmeConfig)
+            .then(function (gmeAuth_) {
+                gmeAuth = gmeAuth_;
+                authorizer = gmeAuth.authorizer;
+                projectAuthParams = {
+                    entityType: authorizer.ENTITY_TYPES.PROJECT,
+                };
+
+                safeStorage = testFixture.getMemoryStorage(logger, gmeConfig, gmeAuth);
+                return safeStorage.openDatabase();
+            })
+            .then(function () {
+                return gmeAuth.addUser('admin', 'admin@example.com', 'plaintext', true,
+                    {overwrite: true, siteAdmin: true});
+            })
+            .nodeify(done);
+    });
+
+    before(function () {
+        // we have to set the config here
+        gmeConfig = testFixture.getGmeConfig();
+
+        logger = testFixture.logger.fork('standalone.startup.spec');
+        gmeConfig.authentication.enable = true;
+        gmeConfig.authentication.allowGuests = false;
+    });
+
+    afterEach(function (done) {
+        server.stop(function () {
+            gmeAuth.unload()
+                .nodeify(done);
+        });
+
+    });
+
+    it('should create startup projects as directed by the config', function (done) {
+        var _gmeConfig = JSON.parse(JSON.stringify(gmeConfig)),
+            serverBaseUrl;
+
+        _gmeConfig.seedProjects.createAtStartup = [
+            {
+                seedId: 'EmptyProject',
+                projectName: 'DefaultOne',
+                creatorId: 'admin',
+                ownerId: 'admin',
+                rights: {
+                    admin: {read: true, write: true}
+                }
+            }
+        ];
+
+        server = WebGME.standaloneServer(_gmeConfig);
+        serverBaseUrl = server.getUrl();
+
+        Q.ninvoke(server, 'start')
+            .then(function () {
+                return testFixture.logIn(server, agent, 'admin', 'plaintext');
+            })
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(serverBaseUrl + '/api/projects')
+                    .end(function (err, res) {
+                        should.equal(res.status, 200);
+                        expect(res.body).to.have.length(1);
+                        expect(res.body[0].owner).to.equal(_gmeConfig.seedProjects.createAtStartup[0].ownerId);
+                        expect(res.body[0].info.kind).to.equal(_gmeConfig.seedProjects.createAtStartup[0].seedId);
+                        deferred.resolve();
+                    });
+
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+
+    it('should not create startup projects that has bad creator assigned to it', function (done) {
+        var _gmeConfig = JSON.parse(JSON.stringify(gmeConfig)),
+            serverBaseUrl;
+
+        _gmeConfig.seedProjects.createAtStartup = [
+            {
+                seedId: 'EmptyProject',
+                projectName: 'DefaultOne',
+                creatorId: 'bad',
+                ownerId: 'admin',
+                rights: {
+                    admin: {read: true, write: true}
+                }
+            }
+        ];
+
+        server = WebGME.standaloneServer(_gmeConfig);
+        serverBaseUrl = server.getUrl();
+
+        Q.ninvoke(server, 'start')
+            .then(function () {
+                return testFixture.logIn(server, agent, 'admin', 'plaintext');
+            })
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(serverBaseUrl + '/api/projects')
+                    .end(function (err, res) {
+                        should.equal(res.status, 200);
+                        expect(res.body).to.have.length(0);
+                        deferred.resolve();
+                    });
+
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+
+    it('should create startup projects and fallback owner to creator', function (done) {
+        var _gmeConfig = JSON.parse(JSON.stringify(gmeConfig)),
+            serverBaseUrl;
+
+        _gmeConfig.seedProjects.createAtStartup = [
+            {
+                seedId: 'EmptyProject',
+                projectName: 'DefaultOne',
+                creatorId: 'admin',
+                rights: {
+                    admin: {read: true, write: true}
+                }
+            }
+        ];
+
+        server = WebGME.standaloneServer(_gmeConfig);
+        serverBaseUrl = server.getUrl();
+
+        Q.ninvoke(server, 'start')
+            .then(function () {
+                return testFixture.logIn(server, agent, 'admin', 'plaintext');
+            })
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(serverBaseUrl + '/api/projects')
+                    .end(function (err, res) {
+                        should.equal(res.status, 200);
+                        expect(res.body).to.have.length(1);
+                        expect(res.body[0].owner).to.equal(_gmeConfig.seedProjects.createAtStartup[0].creatorId);
+                        expect(res.body[0].info.kind).to.equal(_gmeConfig.seedProjects.createAtStartup[0].seedId);
+                        deferred.resolve();
+                    });
+
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+
+    it('should create startup projects and fallback owner to admin', function (done) {
+        var _gmeConfig = JSON.parse(JSON.stringify(gmeConfig)),
+            serverBaseUrl;
+
+        _gmeConfig.authentication.admin = 'admin';
+        _gmeConfig.seedProjects.createAtStartup = [
+            {
+                seedId: 'EmptyProject',
+                projectName: 'DefaultOne',
+                rights: {
+                    admin: {read: true, write: true}
+                }
+            }
+        ];
+
+        server = WebGME.standaloneServer(_gmeConfig);
+        serverBaseUrl = server.getUrl();
+
+        Q.ninvoke(server, 'start')
+            .then(function () {
+                return testFixture.logIn(server, agent, 'admin', 'plaintext');
+            })
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(serverBaseUrl + '/api/projects')
+                    .end(function (err, res) {
+                        should.equal(res.status, 200);
+                        expect(res.body).to.have.length(1);
+                        expect(res.body[0].owner).to.equal(_gmeConfig.authentication.admin);
+                        expect(res.body[0].info.kind).to.equal(_gmeConfig.seedProjects.createAtStartup[0].seedId);
+                        deferred.resolve();
+                    });
+
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+
+    it('should fail to create startup projects with bad owner', function (done) {
+        var _gmeConfig = JSON.parse(JSON.stringify(gmeConfig));
+
+        _gmeConfig.seedProjects.createAtStartup = [
+            {
+                seedId: 'EmptyProject',
+                projectName: 'DefaultOne',
+                creatorId: 'admin',
+                ownerId: 'bad',
+                rights: {
+                    admin: {read: true, write: true}
+                }
+            }
+        ];
+
+        server = WebGME.standaloneServer(_gmeConfig);
+
+        Q.ninvoke(server, 'start')
+            .then(function () {
+                return testFixture.logIn(server, agent, 'admin', 'plaintext');
+            })
+            .then(function () {
+                done(new Error('shoud have failed'));
+            })
+            .catch(function (err) {
+                done();
+            })
+            .finally(function () {
+
+            });
+    });
+});


### PR DESCRIPTION
Introduces the config option seedProjects.createAtStartup an array of projects to be created at startup.
```
{
  seedId: 'EmptyProject',
  projectName: 'StartProject',
  creatorId: 'siteAdminOrAnAdminInOwnerOrg', // If not given the creator will be the authentication.adminAccount
  ownerId: 'MyPublicOrg' // If not given will be the creator
  rights: {
    //owner gets all rights by default
    guest: { read: true }
  }
}
```