### PR TITLE
Closes #81 Allow inferred users to have displayName

### DIFF
--- a/src/common/storage/constants.js
+++ b/src/common/storage/constants.js
@@ -80,7 +80,17 @@
         MONGO_ID: '_id',
         COMMIT_TYPE: 'commit',
         OVERLAY_SHARD_TYPE: 'shard',
-        PROJECT_INFO_KEYS: ['createdAt', 'creator', 'viewedAt', 'viewer', 'modifiedAt', 'modifier', 'kind'],
+        PROJECT_INFO_KEYS: [
+            'createdAt',
+            'creator',
+            'viewedAt',
+            'viewer',
+            'modifiedAt',
+            'modifier',
+            'kind',
+            'description',
+            'icon'
+        ],
         EMPTY_PROJECT_DATA: 'empty',
         PROJECT_ID_SEP: '+',
         PROJECT_DISPLAYED_NAME_SEP: '/',

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -228,7 +228,10 @@ function createAPI(app, mountPath, middlewareOpts) {
                 if (err.message.indexOf('no such user') === 0) {
                     logger.info('Authenticated user did not exist in db, adding:', userId);
                     gmeAuth.addUser(userId, 'em@il', GUID(),
-                        gmeConfig.authentication.inferredUsersCanCreate, {overwrite: false})
+                        gmeConfig.authentication.inferredUsersCanCreate, {
+                            overwrite: false,
+                            displayName: req.userData.displayName
+                        })
                         .then(function (/*userData*/) {
                             return gmeAuth.getUser(userId);
                         })

--- a/src/server/api/webgme-api.raml
+++ b/src/server/api/webgme-api.raml
@@ -223,6 +223,12 @@ resourceTypes:
       description: If true and <b>user.siteAdmin</b> disabled users will be included in response.
       example: true
       required: false
+     displayName:
+      displayName: displayName
+      type: boolean
+      description: If true users with display name will be listed (only id and displayName will be in the response).
+      example: true
+      required: false
     responses:
       200:
         body:

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -496,9 +496,12 @@ function GMEAuth(session, gmeConfig) {
                 if (userData.hasOwnProperty('canCreate')) {
                     oldUserData.canCreate = userData.canCreate === 'true' || userData.canCreate === true;
                 }
+
                 if (userData.hasOwnProperty('siteAdmin')) {
                     oldUserData.siteAdmin = userData.siteAdmin === 'true' || userData.siteAdmin === true;
                 }
+
+                oldUserData.displayName = userData.displayName || oldUserData.displayName;
 
                 if (userData.password) {
                     return Q.ninvoke(bcrypt, 'hash', userData.password, gmeConfig.authentication.salts)
@@ -655,7 +658,8 @@ function GMEAuth(session, gmeConfig) {
                 projects: {},
                 type: CONSTANTS.USER,
                 orgs: [],
-                siteAdmin: options.siteAdmin
+                siteAdmin: options.siteAdmin,
+                displayName: options.displayName,
             };
 
         if (options.hasOwnProperty('data')) {

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -431,7 +431,8 @@ function StandAloneServer(gmeConfig) {
                                 req.userData = {
                                     token: newToken,
                                     newToken: true,
-                                    userId: result.content.userId
+                                    userId: result.content.userId,
+                                    displayName: result.content.displayName
                                 };
                                 logger.debug('generated new token for user', result.content.userId);
                                 res.cookie(gmeConfig.authentication.jwt.cookieId, newToken);
@@ -442,7 +443,8 @@ function StandAloneServer(gmeConfig) {
                     } else {
                         req.userData = {
                             token: token,
-                            userId: result.content.userId
+                            userId: result.content.userId,
+                            displayName: result.content.displayName
                         };
 
                         res.cookie(gmeConfig.authentication.jwt.cookieId, token);

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -390,7 +390,8 @@ function StandAloneServer(gmeConfig) {
                                 req.userData = {
                                     token: newToken,
                                     newToken: true,
-                                    userId: result.content.userId
+                                    userId: result.content.userId,
+                                    displayName: result.content.displayName
                                 };
 
                                 // TODO: Is this the correct way of doing it?
@@ -401,7 +402,8 @@ function StandAloneServer(gmeConfig) {
                     } else {
                         req.userData = {
                             token: token,
-                            userId: result.content.userId
+                            userId: result.content.userId,
+                            displayName: result.content.displayName
                         };
                         next();
                     }

--- a/test/server/api/project/index.project.spec.js
+++ b/test/server/api/project/index.project.spec.js
@@ -456,6 +456,19 @@ describe('PROJECT REST API', function () {
                     });
             });
 
+            it('should patch description info for project /projects/:ownerId/:projectId', function (done) {
+                agent.patch(server.getUrl() + '/api/projects/' + projectName2APIPath(projectName))
+                    .send({description: 'this is a nice project'})
+                    .end(function (err, res) {
+                        expect(res.status).equal(200, err);
+                        expect(res.body).to.have.property('info');
+                        expect(res.body.info).to.include.keys('creator', 'viewer', 'modifier',
+                            'createdAt', 'viewedAt', 'modifiedAt', 'description', 'icon');
+                        expect(res.body.info.description).to.equal('this is a nice project');
+                        done();
+                    });
+            });
+
             it('should not patch info for project if no write access /projects/:ownerId/:projectId', function (done) {
                 agent.patch(server.getUrl() + '/api/projects/' + projectName2APIPath(unauthorizedProjectName))
                     .send({creator: 'PerAlbinHansson'})

--- a/test/server/api/user/index.user.spec.js
+++ b/test/server/api/user/index.user.spec.js
@@ -16,6 +16,10 @@ describe('USER REST API', function () {
         WebGME = testFixture.WebGME,
         expect = testFixture.expect,
         Q = testFixture.Q,
+        fs = require('fs'),
+        jwt = require('jsonwebtoken'),
+        privateKey,
+
 
         superagent = testFixture.superagent;
 
@@ -577,6 +581,8 @@ describe('USER REST API', function () {
                 gmeConfig.authentication.registeredUsersCanCreate = true;
 
                 server = WebGME.standaloneServer(gmeConfig);
+                privateKey = fs.readFileSync(gmeConfig.authentication.jwt.privateKey, 'utf8');
+
                 server.start(done);
             });
 
@@ -731,6 +737,33 @@ describe('USER REST API', function () {
                             });
                     })
                     .catch(done);
+            });
+
+            it('should create user when token in query has displayName', function (done) {
+                var userId = 'user_with_displayName',
+                    dName = 'My Name';
+
+                Q.ninvoke(jwt, 'sign', {userId: userId, displayName: dName}, privateKey, {
+                    algorithm: gmeConfig.authentication.jwt.algorithm,
+                    expiresIn: gmeConfig.authentication.jwt.expiresIn
+                })
+                    .then(function (token) {
+                        agent.get(server.getUrl() + '/api/v1/user')
+                            .query({token: token})
+                            .end(function (err, res) {
+                                try {
+                                    expect(res.status).equal(200, err);
+                                    expect(res.body._id).equal(userId);
+                                    expect(res.body.displayName).equal(dName);
+                                    expect(res.body.canCreate).equal(false);
+                                    expect(res.body.settings).to.deep.equal({});
+                                } catch (e) {
+                                    err = e;
+                                }
+
+                                done(err);
+                            });
+                    });
             });
 
             it('should 401 when user identified via token but user is disabled', function (done) {

--- a/test/server/api/user/index.user.spec.js
+++ b/test/server/api/user/index.user.spec.js
@@ -766,6 +766,33 @@ describe('USER REST API', function () {
                     });
             });
 
+            it('should create user when token in bearer has displayName', function (done) {
+                var userId = 'user_with_displayName',
+                    dName = 'My Name';
+
+                Q.ninvoke(jwt, 'sign', {userId: userId, displayName: dName}, privateKey, {
+                    algorithm: gmeConfig.authentication.jwt.algorithm,
+                    expiresIn: gmeConfig.authentication.jwt.expiresIn
+                })
+                    .then(function (token) {
+                        agent.get(server.getUrl() + '/api/v1/user')
+                            .set('Authorization', 'Bearer ' + token)
+                            .end(function (err, res) {
+                                try {
+                                    expect(res.status).equal(200, err);
+                                    expect(res.body._id).equal(userId);
+                                    expect(res.body.displayName).equal(dName);
+                                    expect(res.body.canCreate).equal(false);
+                                    expect(res.body.settings).to.deep.equal({});
+                                } catch (e) {
+                                    err = e;
+                                }
+
+                                done(err);
+                            });
+                    });
+            });
+
             it('should 401 when user identified via token but user is disabled', function (done) {
                 var userId = 'user_disabled_but_has_token',
                     token;

--- a/test/server/api/users/index.users.spec.js
+++ b/test/server/api/users/index.users.spec.js
@@ -8,7 +8,7 @@
 var testFixture = require('../../../_globals.js');
 
 
-describe.only('USERS REST API', function () {
+describe('USERS REST API', function () {
     'use strict';
 
     var gmeConfig = testFixture.getGmeConfig(),

--- a/test/server/api/users/index.users.spec.js
+++ b/test/server/api/users/index.users.spec.js
@@ -1,0 +1,205 @@
+/*globals require*/
+/*eslint-env node, mocha*/
+
+/**
+ * @author kecso / https://github.com/kecso
+ */
+
+var testFixture = require('../../../_globals.js');
+
+
+describe.only('USERS REST API', function () {
+    'use strict';
+
+    var gmeConfig = testFixture.getGmeConfig(),
+        WebGME = testFixture.WebGME,
+        expect = testFixture.expect,
+        Q = testFixture.Q,
+        gmeAuth,
+        server,
+        agent,
+        superagent = testFixture.superagent;
+
+
+    before(function (done) {
+        gmeConfig.authentication.enable = true;
+
+        testFixture.clearDBAndGetGMEAuth(gmeConfig)
+            .then(function (gmeAuth_) {
+                gmeAuth = gmeAuth_;
+                return Q.allDone([
+                    gmeAuth.addUser('guest', 'guest@example.com', 'guest', true, {overwrite: true, data: {d: 1}}),
+                    gmeAuth.addUser('admin', 'admin@example.com', 'admin', true, {
+                        overwrite: true,
+                        siteAdmin: true
+                    }),
+                    gmeAuth.addUser('disp_user_1', 'd1@mail.com', 'plaintext', false, {
+                        overwrite: true,
+                        displayName: 'Display One',
+                        data: {a: 1}
+                    }),
+                    gmeAuth.addUser('disp_user_2', 'd1@mail.com', 'plaintext', false, {
+                        overwrite: true,
+                        displayName: 'Display Two',
+                        data: {a: 2}
+                    }),
+                    gmeAuth.addUser('no_disp_user_1', 'd1@mail.com', 'plaintext', false, {
+                        overwrite: true,
+                        data: {a: 3}
+                    }),
+                    gmeAuth.addUser('no_disp_user_2', 'd1@mail.com', 'plaintext', false, {
+                        overwrite: true,
+                        data: {a: 4}
+                    })
+                ]);
+            })
+            .then(function () {
+                return Q.allDone([
+                    gmeAuth.authorizeByUserId('disp_user_1', 'project', 'create', {
+                        read: true,
+                        write: true,
+                        delete: false
+                    }),
+                    gmeAuth.authorizeByUserId('disp_user_1', 'unauthorized_project', 'create', {
+                        read: false,
+                        write: false,
+                        delete: false
+                    })
+                ]);
+            })
+            .then(function () {
+                server = WebGME.standaloneServer(gmeConfig);
+                return Q.ninvoke(server, 'start');
+            })
+            .nodeify(done);
+    });
+
+    beforeEach(function () {
+        agent = superagent.agent();
+    });
+
+    after(function (done) {
+        server.stop(function () {
+            gmeAuth.unload()
+                .nodeify(done);
+        });
+    });
+
+    it('should let admin to list everyone with full data', function (done) {
+        testFixture.logIn(server, agent, 'admin', 'admin')
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(server.getUrl() + '/api/users')
+                    .end(function (err, res) {
+                        try {
+                            expect(res.status).equal(200, err);
+                            expect(res.body).to.have.length(6);
+                            res.body.forEach(function (user) {
+                                expect(user).to.include.keys(['projects']);
+                            });
+                        } catch (e) {
+                            deferred.reject(e);
+                            return;
+                        }
+                        deferred.resolve();
+                    });
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+
+    it('should let guest to list only itself', function (done) {
+        testFixture.logIn(server, agent, 'guest', 'guest')
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(server.getUrl() + '/api/users')
+                    .end(function (err, res) {
+                        try {
+                            expect(res.status).equal(200, err);
+                            expect(res.body).to.have.length(1);
+                        } catch (e) {
+                            deferred.reject(e);
+                            return;
+                        }
+                        deferred.resolve();
+                    });
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+
+    it('should let regular user to list everyone without project data', function (done) {
+        testFixture.logIn(server, agent, 'disp_user_1', 'plaintext')
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(server.getUrl() + '/api/users')
+                    .end(function (err, res) {
+                        try {
+                            expect(res.status).equal(200, err);
+                            expect(res.body).to.have.length(6);
+                            res.body.forEach(function (user) {
+                                if (user._id === 'disp_user_1') {
+                                    expect(user.projects).not.to.eql({});
+                                    expect(user.email).not.to.eql('');
+                                } else {
+                                    expect(user.projects).to.eql({});
+                                    expect(user.email).to.eql('');
+                                }
+                            });
+                        } catch (e) {
+                            deferred.reject(e);
+                            return;
+                        }
+                        deferred.resolve();
+                    });
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+
+    it('should list only users with displayName', function (done) {
+        testFixture.logIn(server, agent, 'admin', 'admin')
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(server.getUrl() + '/api/users').query({displayName: true})
+                    .end(function (err, res) {
+                        try {
+                            expect(res.status).equal(200, err);
+                            expect(res.body).to.have.length(2);
+                            res.body.forEach(function (user) {
+                                expect(user).to.include.keys(['displayName']);
+                            });
+                        } catch (e) {
+                            deferred.reject(e);
+                            return;
+                        }
+                        deferred.resolve();
+                    });
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+
+    it('should list users with displayName for guest as well', function (done) {
+        testFixture.logIn(server, agent, 'guest', 'guest')
+            .then(function () {
+                var deferred = Q.defer();
+                agent.get(server.getUrl() + '/api/users').query({displayName: true})
+                    .end(function (err, res) {
+                        try {
+                            expect(res.status).equal(200, err);
+                            expect(res.body).to.have.length(2);
+                            res.body.forEach(function (user) {
+                                expect(user).to.include.keys(['displayName']);
+                            });
+                        } catch (e) {
+                            deferred.reject(e);
+                            return;
+                        }
+                        deferred.resolve();
+                    });
+                return deferred.promise;
+            })
+            .nodeify(done);
+    });
+});

--- a/test/server/storage/metadatastorage.spec.js
+++ b/test/server/storage/metadatastorage.spec.js
@@ -102,7 +102,8 @@ describe('metadatastorage', function () {
             .then(function (data) {
                 expect(data.info).to.deep.equal({
                     createdAt: 'aBitLater', modifiedAt: null, viewedAt: null,
-                    viewer: null, modifier: null, creator: null, kind: null
+                    viewer: null, modifier: null, creator: null, kind: null,
+                    description: null, icon: null
                 });
             })
             .nodeify(done);
@@ -120,7 +121,8 @@ describe('metadatastorage', function () {
             .then(function (data) {
                 expect(data.info).to.deep.equal({
                     createdAt: 'justNow', modifiedAt: null, viewedAt: null,
-                    viewer: null, modifier: null, creator: null, kind: null
+                    viewer: null, modifier: null, creator: null, kind: null,
+                    description: null, icon: null
                 });
             })
             .nodeify(done);
@@ -138,7 +140,8 @@ describe('metadatastorage', function () {
             .then(function (data) {
                 expect(data.info).to.deep.equal({
                     createdAt: 'justNow', modifiedAt: null, viewedAt: null,
-                    viewer: null, modifier: null, creator: null, kind: null
+                    viewer: null, modifier: null, creator: null, kind: null,
+                    description: null, icon: null
                 });
             })
             .nodeify(done);
@@ -156,7 +159,9 @@ describe('metadatastorage', function () {
                 creator: 'user',
                 viewer: 'user',
                 modifier: 'user',
-                kind: 'someKindOfProject'
+                kind: 'someKindOfProject',
+                description: '',
+                icon: null
             };
         store.addProject(ownerName, projectName, info)
             .then(function (projectId) {


### PR DESCRIPTION
Inferred users can now send displayName in their token and those will be stored and respected in the basic user database.
Also, this change introduces 'description' and 'icon' field for the project info.