### PR TITLE
Remove restriction on zip file size of complex blob artifact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,34 @@
         "normalize-path": "2.1.1"
       }
     },
+    "archiver": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
+      "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "async": "2.0.1",
+        "buffer-crc32": "0.2.13",
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "readable-stream": "2.3.3",
+        "tar-stream": "1.5.5",
+        "zip-stream": "1.2.0"
+      }
+    },
+    "archiver-utils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.5",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
+      }
+    },
     "argh": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.4.tgz",
@@ -430,6 +458,44 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+    },
+    "bl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "requires": {
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
     },
     "blob": {
       "version": "0.0.4",
@@ -731,6 +797,11 @@
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1055,6 +1126,17 @@
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
+    "compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.3"
+      }
+    },
     "compressible": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
@@ -1255,6 +1337,20 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crc": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
+    },
+    "crc32-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "requires": {
+        "crc": "3.5.0",
+        "readable-stream": "2.3.3"
+      }
     },
     "create-ecdh": {
       "version": "4.0.0",
@@ -3868,6 +3964,14 @@
       "dev": true,
       "optional": true
     },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -5956,6 +6060,17 @@
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg="
     },
+    "tar-stream": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "requires": {
+        "bl": "1.2.2",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
     "text": {
       "version": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f"
     },
@@ -6672,6 +6787,17 @@
         "lodash.get": "4.4.2",
         "lodash.isequal": "4.5.0",
         "validator": "9.4.0"
+      }
+    },
+    "zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.2",
+        "lodash": "4.17.5",
+        "readable-stream": "2.3.3"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3513,21 +3513,6 @@
         "verror": "1.10.0"
       }
     },
-    "jszip": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
-      "integrity": "sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=",
-      "requires": {
-        "pako": "0.2.9"
-      },
-      "dependencies": {
-        "pako": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
-        }
-      }
-    },
     "jwa": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "adm-zip": "0.4.7",
     "agentkeepalive": "3.3.0",
+    "archiver": "^2.1.1",
     "aws-sdk": "2.142.0",
     "bcryptjs": "2.4.3",
     "body-parser": "1.18.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "ink-docstrap": "1.3.0",
     "jsdoc": "3.5.5",
     "jsonwebtoken": "8.1.0",
-    "jszip": "2.5.0",
     "marked": "0.3.12",
     "method-override": "2.3.10",
     "mime": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "adm-zip": "0.4.7",
     "agentkeepalive": "3.3.0",
-    "archiver": "^2.1.1",
+    "archiver": "2.1.1",
     "aws-sdk": "2.142.0",
     "bcryptjs": "2.4.3",
     "body-parser": "1.18.2",
@@ -66,7 +66,7 @@
     "jsdoc": "3.5.5",
     "jsonwebtoken": "8.1.0",
     "jszip": "2.5.0",
-    "marked": "^0.3.12",
+    "marked": "0.3.12",
     "method-override": "2.3.10",
     "mime": "1.4.1",
     "minimatch": "3.0.4",

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -364,11 +364,8 @@ define([
         }
 
         if (typeof window === 'undefined') {
-            req.agent(this.keepaliveAgent);
-        }
-
-        if (typeof window === 'undefined') {
             // running on node
+            req.agent(this.keepaliveAgent);
             var Writable = require('stream').Writable;
             var BuffersWritable = function (options) {
                 Writable.call(this, options);
@@ -428,6 +425,24 @@ define([
         }
 
         return deferred.promise.nodeify(callback);
+    };
+
+    BlobClient.prototype.getStreamObject = function (metadataHash, writeStream, subpath) {
+        this.logger.debug('getStreamObject', metadataHash, subpath);
+
+        var req = superagent.get(this.getViewURL(metadataHash, subpath));
+
+        if (this.webgmeToken) {
+            req.set('Authorization', 'Bearer ' + this.webgmeToken);
+        }
+
+        if (typeof Buffer !== 'undefined') {
+            // running on node
+            req.agent(this.keepaliveAgent);
+            req.pipe(writeStream);
+        } else {
+            throw new Error('streamObject only supported under nodejs, use getObject instead.');
+        }
     };
 
     /**

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -445,7 +445,7 @@ define([
      * blobClient.getStreamObject(metadataHash, writeStream);
      *
      * @param {string} metadataHash - hash of metadata for object.
-     * @param {Writable Stream} writeStream - write stream the requested data will be piped to.
+     * @param {stream.Writable} writeStream - stream the requested data will be piped to.
      * @param {string} [subpath] - optional file-like path to sub-object if complex blob
      */
     BlobClient.prototype.getStreamObject = function (metadataHash, writeStream, subpath) {

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -427,6 +427,27 @@ define([
         return deferred.promise.nodeify(callback);
     };
 
+    /**
+     * If running under nodejs and getting large objects use this method to pipe the downloaded
+     * object to your provided writeStream.
+     * @example
+     * // Piping object to the filesystem..
+     * var writeStream = fs.createWriteStream('my.zip');
+     *
+     * writeStream.on('error', function (err) {
+     *   // handle error
+     * });
+     *
+     * writeStream.on('finish', function () {
+     *   // my.zip exists at this point
+     * });
+     *
+     * blobClient.getStreamObject(metadataHash, writeStream);
+     *
+     * @param {string} metadataHash - hash of metadata for object.
+     * @param {Writable Stream} writeStream - write stream the requested data will be piped to.
+     * @param {string} [subpath] - optional file-like path to sub-object if complex blob
+     */
     BlobClient.prototype.getStreamObject = function (metadataHash, writeStream, subpath) {
         this.logger.debug('getStreamObject', metadataHash, subpath);
 

--- a/src/common/blob/Readme.md
+++ b/src/common/blob/Readme.md
@@ -1,8 +1,6 @@
 ## Binary Large Object Storage ##
 
 ### TODO ###
-
-- test file upload bigger than 1MB through UI
 - gracefully log soft link circular references
 - add object compare function - complex objects might have the same content even though the hashes are not the same.
 
@@ -36,12 +34,6 @@
 
 
 ### Limitations ###
-
-- `complex` artifact cannot be bigger than 1GB. Storage can store it, but jszip cannot create a zip package to download it.
- V8 max buffer size is 1GB (kMaxLength).
- We need a different implementation to generate the zip.
-
-
 
 ### Design ###
 

--- a/test/common/blob/BlobClient.spec.js
+++ b/test/common/blob/BlobClient.spec.js
@@ -16,6 +16,8 @@ describe('BlobClient', function () {
         expect = testFixture.expect,
         BlobClient = testFixture.BlobClient,
         Artifact = testFixture.requirejs('blob/Artifact'),
+        fs = testFixture.fs,
+        Q = testFixture.Q,
         server,
         nodeTLSRejectUnauthorized,
         bcParam = {};
@@ -60,8 +62,7 @@ describe('BlobClient', function () {
             expect(typeof bc.getDownloadURL === 'function').to.equal(true);
             expect(bc.getDownloadURL()).to.contain('download');
             expect(bc.getDownloadURL('1234567890abcdef')).to.contain('1234567890abcdef');
-            expect(bc.getDownloadURL('1234567890abcdef', 'some/path/to/a/file.txt')).
-                to.contain('1234567890abcdef/some%2Fpath%2Fto%2Fa%2Ffile.txt');
+            expect(bc.getDownloadURL('1234567890abcdef', 'some/path/to/a/file.txt')).to.contain('1234567890abcdef/some%2Fpath%2Fto%2Fa%2Ffile.txt');
         });
 
         it('getMetaDataUrl should be concatenation of origin and getRelativeMetaDataUrl', function () {
@@ -289,9 +290,9 @@ describe('BlobClient', function () {
         if (typeof global !== 'undefined') {
             it('should create zip', function (done) {
                 var data = base64DecToArr('UEsDBAoAAAAAACNaNkWtbMPDBwAAAAcAAAAIAAAAZGF0YS5ia' +
-                                          'W5kYXRhIA0KUEsBAj8ACgAAAAAA\n' +
-                                          'I1o2Ra1sw8MHAAAABwAAAAgAJAAAAAAAAAAgAAAAAAAAAGRhdGEuYmluCgAgAAAAAAABABgAn3xF\n' +
-                                          'poDWzwGOVUWmgNbPAY5VRaaA1s8BUEsFBgAAAAABAAEAWgAAAC0AAAAAAA==');
+                    'W5kYXRhIA0KUEsBAj8ACgAAAAAA\n' +
+                    'I1o2Ra1sw8MHAAAABwAAAAgAJAAAAAAAAAAgAAAAAAAAAGRhdGEuYmluCgAgAAAAAAABABgAn3xF\n' +
+                    'poDWzwGOVUWmgNbPAY5VRaaA1s8BUEsFBgAAAAABAAEAWgAAAC0AAAAAAA==');
                 createZip(data, done);
             });
         }
@@ -300,9 +301,9 @@ describe('BlobClient', function () {
             // need this in package.json: "node-remote": "localhost"
             it('should create zip from Buffer', function (done) {
                 var data = base64DecToArr('UEsDBAoAAAAAACNaNkWtbMPDBwAAAAcAAAAIAAAAZGF0YS5ia' +
-                                          'W5kYXRhIA0KUEsBAj8ACgAAAAAA\n' +
-                                          'I1o2Ra1sw8MHAAAABwAAAAgAJAAAAAAAAAAgAAAAAAAAAGRhdGEuYmluCgAgAAAAAAABABgAn3xF\n' +
-                                          'poDWzwGOVUWmgNbPAY5VRaaA1s8BUEsFBgAAAAABAAEAWgAAAC0AAAAAAA==');
+                    'W5kYXRhIA0KUEsBAj8ACgAAAAAA\n' +
+                    'I1o2Ra1sw8MHAAAABwAAAAgAJAAAAAAAAAAgAAAAAAAAAGRhdGEuYmluCgAgAAAAAAABABgAn3xF\n' +
+                    'poDWzwGOVUWmgNbPAY5VRaaA1s8BUEsFBgAAAAABAAEAWgAAAC0AAAAAAA==');
                 createZip(new Buffer(data), done);
             });
         }
@@ -587,7 +588,7 @@ describe('BlobClient', function () {
                 process.env.NODE_TLS_REJECT_UNAUTHORIZED = nodeTLSRejectUnauthorized;
                 proxy.close(function (err1) {
                     done(err || err1);
-                });      
+                });
             });
         });
 
@@ -650,9 +651,9 @@ describe('BlobClient', function () {
         if (typeof global !== 'undefined') {
             it('should create zip', function (done) {
                 var data = base64DecToArr('UEsDBAoAAAAAACNaNkWtbMPDBwAAAAcAAAAIAAAAZGF0YS5ia' +
-                                          'W5kYXRhIA0KUEsBAj8ACgAAAAAA\n' +
-                                          'I1o2Ra1sw8MHAAAABwAAAAgAJAAAAAAAAAAgAAAAAAAAAGRhdGEuYmluCgAgAAAAAAABABgAn3xF\n' +
-                                          'poDWzwGOVUWmgNbPAY5VRaaA1s8BUEsFBgAAAAABAAEAWgAAAC0AAAAAAA==');
+                    'W5kYXRhIA0KUEsBAj8ACgAAAAAA\n' +
+                    'I1o2Ra1sw8MHAAAABwAAAAgAJAAAAAAAAAAgAAAAAAAAAGRhdGEuYmluCgAgAAAAAAABABgAn3xF\n' +
+                    'poDWzwGOVUWmgNbPAY5VRaaA1s8BUEsFBgAAAAABAAEAWgAAAC0AAAAAAA==');
                 createZip(data, done);
             });
         }
@@ -661,9 +662,9 @@ describe('BlobClient', function () {
             // need this in package.json: "node-remote": "localhost"
             it('should create zip from Buffer', function (done) {
                 var data = base64DecToArr('UEsDBAoAAAAAACNaNkWtbMPDBwAAAAcAAAAIAAAAZGF0YS5ia' +
-                                          'W5kYXRhIA0KUEsBAj8ACgAAAAAA\n' +
-                                          'I1o2Ra1sw8MHAAAABwAAAAgAJAAAAAAAAAAgAAAAAAAAAGRhdGEuYmluCgAgAAAAAAABABgAn3xF\n' +
-                                          'poDWzwGOVUWmgNbPAY5VRaaA1s8BUEsFBgAAAAABAAEAWgAAAC0AAAAAAA==');
+                    'W5kYXRhIA0KUEsBAj8ACgAAAAAA\n' +
+                    'I1o2Ra1sw8MHAAAABwAAAAgAJAAAAAAAAAAgAAAAAAAAAGRhdGEuYmluCgAgAAAAAAABABgAn3xF\n' +
+                    'poDWzwGOVUWmgNbPAY5VRaaA1s8BUEsFBgAAAAABAAEAWgAAAC0AAAAAAA==');
                 createZip(new Buffer(data), done);
             });
         }
@@ -818,6 +819,78 @@ describe('BlobClient', function () {
                     });
                 });
             });
+        });
+
+        it('streamObject to a file', function (done) {
+            var bc = new BlobClient(bcParam),
+                artie = bc.createArtifact('artie');
+
+            Q.allDone([
+                artie.addFile('1.txt', 'text 1'),
+                artie.addFile('2.txt', 'text 2'),
+                artie.addFile('3.txt', 'text 3')
+            ])
+                .then(function () {
+                    return artie.save();
+                })
+                .then(function (metadataHash) {
+                    var zipFile = testFixture.path.join('test-tmp', 'streamed.zip'),
+                        deferred = Q.defer(),
+                        writeStream = fs.createWriteStream(zipFile);
+
+                    writeStream.on('error', function (err) {
+                        deferred.reject(err);
+                    });
+
+                    writeStream.on('finish', function () {
+                        deferred.resolve(zipFile);
+                    });
+
+                    bc.getStreamObject(metadataHash, writeStream);
+
+                    return deferred.promise;
+                })
+                .then(function (zip) {
+                    // This throws if it does not exist
+                    return Q.ninvoke(fs, 'unlink', zip);
+                })
+                .nodeify(done);
+        });
+
+        it('streamObject with subpath to a file', function (done) {
+            var bc = new BlobClient(bcParam),
+                artie = bc.createArtifact('artie');
+
+            Q.allDone([
+                artie.addFile('1.txt', 'text 1'),
+                artie.addFile('2.txt', 'text 2'),
+                artie.addFile('3.txt', 'text 3')
+            ])
+                .then(function () {
+                    return artie.save();
+                })
+                .then(function (metadataHash) {
+                    var txtFile = testFixture.path.join('test-tmp', '1.txt'),
+                        deferred = Q.defer(),
+                        writeStream = fs.createWriteStream(txtFile);
+
+                    writeStream.on('error', function (err) {
+                        deferred.reject(err);
+                    });
+
+                    writeStream.on('finish', function () {
+                        deferred.resolve(txtFile);
+                    });
+
+                    bc.getStreamObject(metadataHash, writeStream, '1.txt');
+
+                    return deferred.promise;
+                })
+                .then(function (txtFile) {
+                    // This throws if it does not exist
+                    return Q.ninvoke(fs, 'unlink', txtFile);
+                })
+                .nodeify(done);
         });
     });
 

--- a/test/plugin/coreplugins/MetaGMEParadigmImporter/MetaGMEParadigmImporter.spec.js
+++ b/test/plugin/coreplugins/MetaGMEParadigmImporter/MetaGMEParadigmImporter.spec.js
@@ -115,7 +115,7 @@ describe('Plugin MetaGMEParadigmImporter', function () {
             };
 
         pluginManager.executePlugin(pluginName, pluginConfig, pluginContext, function (err, result) {
-            expect(err).to.equal('Blob hash is invalid');
+            expect(err.message).to.equal('Blob hash is invalid');
             expect(result.success).to.equal(false);
             done();
         });
@@ -131,7 +131,7 @@ describe('Plugin MetaGMEParadigmImporter', function () {
             };
 
         pluginManager.executePlugin(pluginName, pluginConfig, pluginContext, function (err, result) {
-            expect(err).to.equal('Blob hash is invalid');
+            expect(err.message).to.equal('Blob hash is invalid');
             expect(result.success).to.equal(false);
             done();
         });

--- a/test/server/middleware/blob/BlobRunPluginClient.spec.js
+++ b/test/server/middleware/blob/BlobRunPluginClient.spec.js
@@ -44,7 +44,7 @@ describe('BlobServer', function () {
         var bc = new BlobClient(blobBackend, logger.fork('blob'));
 
         bc.getObject('invalid', function (err /*, res*/) {
-            if (err === 'Blob hash is invalid') {
+            if (err.message === 'Blob hash is invalid') {
                 done();
                 return;
             } else if (err) {


### PR DESCRIPTION
Using [archiver](https://archiverjs.com/docs/) instead of jszip allows streaming in the bundled files to the zip file which in turn is streamed to the requester.

This PR also adds `getObjectStream` on the blob-client to enable users to pass in a writable-stream when retrieving an object from the blob-storage. That way the entire buffer doesn't need to reside in memory (although outside of v8).

#### Potential breaking change!
This PR also makes sure  the BlobBackendBase rejects with Errors rather than string. This API is relatively private and typically shouldn't break anything.