### PR TITLE
Add addresses field and more details for webSockets in /api/status endpoint

### DIFF
--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -2293,9 +2293,10 @@ function createAPI(app, mountPath, middlewareOpts) {
     router.get('/status', ensureAuthenticated, function (req, res, next) {
         var userId = getUserId(req),
             result = {
+                addresses: middlewareOpts.addresses,
                 addOns: null,
                 serverWorkers: null,
-                webSockets: null
+                webSockets: null,
             };
 
         gmeAuth.getUser(userId)

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -630,6 +630,7 @@ function StandAloneServer(gmeConfig) {
     middlewareOpts = {  //TODO: Pass this to every middleware They must not modify the options!
         gmeConfig: gmeConfig,
         logger: logger,
+        IPs: [],
         ensureAuthenticated: ensureAuthenticated,
         getUserId: getUserId,
         gmeAuth: __gmeAuth,
@@ -918,12 +919,10 @@ function StandAloneServer(gmeConfig) {
 
     logger.debug('gmeConfig of webgme server', {metadata: gmeConfig});
     var networkIfs = OS.networkInterfaces(),
-        addresses = 'Valid addresses of gme web server: ',
+        addresses = [],
         forEveryNetIf = function (netIf) {
             if (netIf.family === 'IPv4') {
-                var address = 'http' + '://' +
-                    netIf.address + ':' + gmeConfig.server.port;
-                addresses = addresses + '  ' + address;
+                addresses.push('http://' + netIf.address + ':' + gmeConfig.server.port);
             }
         };
 
@@ -931,7 +930,9 @@ function StandAloneServer(gmeConfig) {
         networkIfs[dev].forEach(forEveryNetIf);
     }
 
-    logger.info(addresses);
+    logger.info('Valid addresses of gme web server: ', addresses.join('  '));
+
+    middlewareOpts.addresses = addresses;
 
     logger.debug('standalone server initialization completed');
 

--- a/test/server/api/index.spec.js
+++ b/test/server/api/index.spec.js
@@ -959,6 +959,7 @@ describe('ORGANIZATION REST API', function () {
                         try {
                             expect(res.status).equal(200, err);
                             expect(typeof res.body).to.equal('object');
+                            expect(res.body.addresses instanceof Array).to.equal(true);
                             expect(res.body.addOns).to.equal(null);
                             expect(typeof res.body.serverWorkers).to.equal('object');
                             expect(res.body.webSockets instanceof Array).to.equal(true);


### PR DESCRIPTION
Example `/api/status`

```javascript
    {
        "addresses": [
            "http://129.59.105.64:8888",
            "http://192.168.56.1:8888",
            "http://127.0.0.1:8888"
        ],
        "addOns": null,
        "serverWorkers": {
            "waitingRequests": [],
            "workers": [
                {
                    "pid": "2444",
                    "state": "free"
                }
            ]
        },
        "webSockets": [
            {
                "socketId": "sT99i-DTg_hjeSebAAAA",
                "userId": "guest",
                "connectedSince": "Thu May 31 2018 09:21:41 GMT-0500 (Central Daylight Time)",
                "branchRooms": [
                    {
                        "projectId": "guest+ap",
                        "branchName": "master"
                    }
                ]
            }
        ]
    }
```