### PR TITLE
Fixes #82 by adding core.getCommonBase and getCommonParent and equivalents on client API

### DIFF
--- a/src/client/gmeNodeGetter.js
+++ b/src/client/gmeNodeGetter.js
@@ -34,11 +34,6 @@ define([], function () {
         this._storeNode = storeNode;
     }
 
-    GMENode.prototype.getParentId = function () {
-        //just for sure, as it may missing from the cache
-        return this._storeNode(this._state.core.getParent(this._state.nodes[this._id].node));
-    };
-
     GMENode.prototype.getId = function () {
         return this._id;
     };
@@ -51,6 +46,22 @@ define([], function () {
         return this._state.core.getGuid(this._state.nodes[this._id].node);
     };
 
+    GMENode.prototype.getParentId = function () {
+        //just for sure, as it may missing from the cache
+        return this._storeNode(this._state.core.getParent(this._state.nodes[this._id].node));
+    };
+
+    GMENode.prototype.getCommonParentId = function (/*otherNodeIds*/) {
+        var nodesArr = (arguments.length === 1 ? [arguments[0]] : Array.apply(null, arguments)),
+            self = this;
+
+        nodesArr.push(this._id);
+
+        return this._storeNode(this._state.core.getCommonParent.apply(this._state.core, nodesArr.map(function (id) {
+            return _getNode(self._state.nodes, id);
+        })));
+    };
+
     GMENode.prototype.getChildrenIds = function () {
         return this._state.core.getChildrenPaths(this._state.nodes[this._id].node);
     };
@@ -61,6 +72,17 @@ define([], function () {
 
     GMENode.prototype.getBaseId = function () {
         return this._storeNode(this._state.core.getBase(this._state.nodes[this._id].node));
+    };
+
+    GMENode.prototype.getCommonBaseId = function (/*otherNodeIds*/) {
+        var nodesArr = (arguments.length === 1 ? [arguments[0]] : Array.apply(null, arguments)),
+            self = this;
+
+        nodesArr.push(this._id);
+
+        return this._storeNode(this._state.core.getCommonBase.apply(this._state.core, nodesArr.map(function (id) {
+            return _getNode(self._state.nodes, id);
+        })));
     };
 
     GMENode.prototype.isValidNewBase = function (basePath) {

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -310,6 +310,34 @@ define([
         }
     }
 
+    function getCommonAncestor(node1, node2, getter) {
+        function getChain(node) {
+            var ancestors = [];
+
+            while (node) {
+                ancestors.push(node);
+                node = getter(node);
+            }
+
+            return ancestors;
+        }
+
+        var ancestors2 = getChain(node2),
+            i;
+
+        while (node1) {
+            for (i = 0; i < ancestors2.length; i += 1) {
+                if (node1 === ancestors2[i]) {
+                    return node1;
+                }
+            }
+
+            node1 = getter(node1);
+        }
+
+        return null;
+    }
+
     /**
      * @param {ProjectInterface} project - project connected to storage
      * @param {object} options - contains logging information
@@ -364,6 +392,34 @@ define([
             ensureNode(node, 'node');
 
             return core.getParent(node);
+        };
+
+        /**
+         * Returns the common parent node of all supplied nodes.
+         * @param {...module:Core~Node} nodes - a variable number of nodes to compare
+         *
+         * @return {module:Core~Node | null} The common base or null if no nodes were passed.
+         * @example
+         * core.getCommonParent(node1, node2, node3);
+         * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         */
+        this.getCommonParent = function () {
+            var nodesArr = (arguments.length === 1 ? [arguments[0]] : Array.apply(null, arguments)),
+                result,
+                i;
+
+            nodesArr.forEach(function (node, idx) {
+                ensureNode(node, 'arguments[' + idx + ']');
+            });
+
+            result = nodesArr[0];
+
+            for (i = 1; i < nodesArr.length; i += 1) {
+                result = getCommonAncestor(result, nodesArr[i], core.getParent);
+            }
+
+            return result || null;
         };
 
         /**
@@ -1219,6 +1275,34 @@ define([
             ensureNode(node, 'node');
 
             return core.getBase(node);
+        };
+
+        /**
+         * Returns the common base node of all supplied nodes.
+         * @param {...module:Core~Node} nodes - a variable number of nodes to compare
+         *
+         * @return {module:Core~Node | null} The common base or null if e.g. the root node was passed.
+         * @example
+         * core.getCommonBase(node1, node2, node3);
+         * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
+         * @throws {CoreAssertError} If some internal error took place inside the core layers.
+         */
+        this.getCommonBase = function () {
+            var nodesArr = (arguments.length === 1 ? [arguments[0]] : Array.apply(null, arguments)),
+                result,
+                i;
+
+            nodesArr.forEach(function (node, idx) {
+                ensureNode(node, 'arguments[' + idx + ']');
+            });
+
+            result = nodesArr[0];
+
+            for (i = 1; i < nodesArr.length; i += 1) {
+                result = getCommonAncestor(result, nodesArr[i], core.getBase);
+            }
+
+            return result || null;
         };
 
         /**

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -471,6 +471,7 @@ function importProject(storage, parameters, callback) {
                     core: core,
                     jsonProject: projectJson,
                     rootNode: null,
+                    FCO: null,
                     rootHash: null,
                     blobClient: blobClient
                 };
@@ -495,6 +496,7 @@ function importProject(storage, parameters, callback) {
                 })
                 .then(function (rootNode) {
                     result.rootNode = rootNode;
+                    result.FCO = result.core.getFCO(rootNode);
                     deferred.resolve(result);
                 })
                 .catch(deferred.reject);

--- a/test/client/js/client/gmeNodeGetter.spec.js
+++ b/test/client/js/client/gmeNodeGetter.spec.js
@@ -17,8 +17,11 @@ describe('gmeNodeGetter', function () {
         context,
         basicState,
         basicStoreNode = function (node) {
+            var path;
+
             if (node) {
-                return context.core.getPath(node) || null;
+                path = context.core.getPath(node);
+                return typeof path === 'string' ? path : null;
             }
             return null;
         },
@@ -169,6 +172,8 @@ describe('gmeNodeGetter', function () {
         expect(typeof node.getMixinPaths).to.equal('function');
         expect(typeof node.canSetAsMixin).to.equal('function');
         expect(typeof node.isReadOnly).to.equal('function');
+        expect(typeof node.getCommonBaseId).to.equal('function');
+        expect(typeof node.getCommonParentId).to.equal('function');
     });
 
     it('should return the parentId', function () {
@@ -795,4 +800,81 @@ describe('gmeNodeGetter', function () {
         expect(node.isValidTargetOf('/1303043463/1448030591', 'setPtr')).to.eql(false);
     });
 
+
+    it('should return the common base', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode);
+
+        // Ensure the node is loaded
+        getNode('/1303043463/2119137141', logger, basicState, basicStoreNode);
+
+        expect(node.getCommonBaseId('/1303043463/2119137141')).to.eql('/1');
+    });
+
+    it('should return the common base of multiple nodes', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode);
+
+        // Ensure the nodes are loaded
+        getNode('/175547009/1817665259', logger, basicState, basicStoreNode);
+        getNode('/1303043463/2119137141', logger, basicState, basicStoreNode);
+
+        expect(node.getCommonBaseId('/1303043463/2119137141', '/175547009/1817665259')).to.eql('/1');
+    });
+
+    it('should return the common base null if root provided', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode);
+
+        // Ensure the node are loaded
+        getNode('/1303043463/2119137141', logger, basicState, basicStoreNode);
+        getNode('', logger, basicState, basicStoreNode);
+
+        expect(node.getCommonBaseId('/1303043463/2119137141', '')).to.eql(null);
+    });
+
+    it('should throw at getCommonBaseId if compare-node not loaded/does not exist', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode),
+            threw;
+
+        try {
+            expect(node.getCommonBaseId('/does/not/exist')).to.eql(null);
+        } catch (e) {
+            threw = e;
+        }
+
+        expect(!!threw).to.equal(true);
+        expect(threw.message).to.include('is not a valid node');
+    });
+
+    it('should return the common parent of two nodes', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode);
+
+        // Ensure the node are loaded
+        getNode('/175547009/1817665259', logger, basicState, basicStoreNode);
+
+        expect(node.getCommonParentId('/175547009/1817665259')).to.eql('/175547009');
+    });
+
+    it('should return the common parent with multiple nodes', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode);
+
+        // Ensure the node are loaded
+        getNode('/175547009/1817665259', logger, basicState, basicStoreNode);
+        getNode('/1303043463/2119137141', logger, basicState, basicStoreNode);
+        getNode('', logger, basicState, basicStoreNode);
+
+        expect(node.getCommonParentId('/175547009/1817665259', '/1303043463/2119137141', '')).to.eql('');
+    });
+
+    it('should throw at getCommonParentId if compare node not loaded/does not exist', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode),
+            threw;
+
+        try {
+            expect(node.getCommonParentId('/does/not/exist')).to.eql(null);
+        } catch (e) {
+            threw = e;
+        }
+
+        expect(!!threw).to.equal(true);
+        expect(threw.message).to.include('is not a valid node');
+    });
 });

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -127,7 +127,8 @@ describe('core', function () {
                 'getChildDefinitionInfo', 'getValidTargetPaths', 'getOwnValidTargetPaths',
                 'isValidAspectMemberOf', 'moveAspectMetaTarget', 'movePointerMetaTarget',
                 'renameAttributeMeta', 'moveMember', 'getOwnValidPointerNames', 'getOwnValidSetNames',
-                'getValidAspectTargetPaths', 'getOwnValidAspectTargetPaths', 'isValidNewChild'
+                'getValidAspectTargetPaths', 'getOwnValidAspectTargetPaths', 'isValidNewChild',
+                'getCommonBase', 'getCommonParent'
             ];
 
         //console.log(_.difference(functions, Matches));
@@ -5093,6 +5094,79 @@ describe('core', function () {
             })
             .catch(function (err) {
                 expect(err.message).to.include('Cannot load commit object');
+            })
+            .nodeify(done);
+    });
+
+    it('getCommonBase/Parent should return null with no arguments', function () {
+        expect(core.getCommonParent()).to.equal(null);
+        expect(core.getCommonBase()).to.equal(null);
+    });
+
+    it('getCommonBase should return same node if only one provided', function () {
+        expect(core.getCommonBase(ir.rootNode)).to.equal(ir.rootNode);
+        expect(core.getCommonBase(ir.FCO)).to.equal(ir.FCO);
+    });
+
+    it('getCommonParent should return same node if only one provided', function () {
+        expect(core.getCommonParent(ir.rootNode)).to.equal(ir.rootNode);
+        expect(core.getCommonParent(ir.FCO)).to.equal(ir.FCO);
+    });
+
+    it('getCommonBase should return null if ROOT provided', function () {
+        expect(core.getCommonBase(ir.rootNode, ir.FCO)).to.equal(null);
+    });
+
+    it('getCommonParent should return ROOT if ROOT provided', function () {
+        expect(core.getCommonParent(ir.rootNode, ir.FCO)).to.equal(ir.rootNode);
+    });
+
+    it('getCommonBase for more than two nodes', function (done) {
+        prepRootNode()
+            .then(function (rootNode) {
+                var fco = core.getFCO(rootNode);
+
+                var child1 = core.createNode({base: fco, parent: rootNode});
+                var child2 = core.createNode({base: child1, parent: rootNode});
+                var child3 = core.createNode({base: fco, parent: rootNode});
+                var child4 = core.createNode({base: child3, parent: rootNode});
+
+
+                expect(core.getCommonBase(child1, child2, fco)).to.equal(fco);
+                expect(core.getCommonBase(fco, child1, child2)).to.equal(fco);
+                expect(core.getCommonBase(child2, fco, child1)).to.equal(fco);
+
+                expect(core.getCommonBase(child4, child2)).to.equal(fco);
+
+                expect(core.getCommonBase(child4, child3)).to.equal(child3);
+
+                expect(core.getCommonBase(child2, fco, child1, rootNode)).to.equal(null);
+            })
+            .nodeify(done);
+    });
+
+    it('getCommonParent for more than two nodes', function (done) {
+        prepRootNode()
+            .then(function (rootNode) {
+                var fco = core.getFCO(rootNode);
+
+                var child1 = core.createNode({base: fco, parent: rootNode});
+                var child2 = core.createNode({base: fco, parent: child1});
+                var child3 = core.createNode({base: fco, parent: child2});
+
+                var child4 = core.createNode({base: fco, parent: rootNode});
+                var child5 = core.createNode({base: fco, parent: child4});
+
+
+                expect(core.getCommonParent(child1, child2, fco)).to.equal(rootNode);
+                expect(core.getCommonParent(fco, child1, child2)).to.equal(rootNode);
+                expect(core.getCommonParent(child2, fco, child1)).to.equal(rootNode);
+
+                expect(core.getCommonParent(child2, child3)).to.equal(child2);
+
+                expect(core.getCommonParent(child4, child5)).to.equal(child4);
+
+                expect(core.getCommonParent(child3, child5)).to.equal(rootNode);
             })
             .nodeify(done);
     });


### PR DESCRIPTION
Once merged and released docs will be available at:
[getCommonBase](https://editor.webgme.org/docs/source/Core.html#getCommonBase__anchor]
[getCommonParent](https://editor.webgme.org/docs/source/Core.html#getCommonParent__anchor]

The equivalent methods on the client are:
`node.getCommonBaseId` and `node.getCommonParentId`
