### PR TITLE
Better handling of expired tokens in websocket

### DIFF
--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -98,7 +98,7 @@ define([
         this.close = function (callback) {
             logger.debug('Closing storage, openProjects', Object.keys(projects));
 
-            return Q.all(Object.keys(projects)
+            return Q.allSettled(Object.keys(projects)
                 .map(function (projectId) {
                     return self.closeProject(projectId);
                 }))
@@ -182,7 +182,7 @@ define([
             logger.debug('closeProject', projectId);
 
             if (projects[projectId]) {
-                return Q.all(Object.keys(projects[projectId].branches)
+                return Q.allSettled(Object.keys(projects[projectId].branches)
                     .map(function (branchName) {
                         return self.closeBranch(projectId, branchName);
                     }))

--- a/src/server/storage/websocket.js
+++ b/src/server/storage/websocket.js
@@ -63,7 +63,10 @@ function WebSocket(storage, mainLogger, gmeConfig, gmeAuth, workerManager) {
                 .catch(function (err) {
                     if (err.name === 'TokenExpiredError') {
                         logger.debug('JWT_EXPIRED for socket', socket.id);
-                        socket.emit(CONSTANTS.JWT_EXPIRED, {});
+                        if (!socket[CONSTANTS.JWT_EXPIRED]) {
+                            socket[CONSTANTS.JWT_EXPIRED] = true;
+                            socket.emit(CONSTANTS.JWT_EXPIRED, {});
+                        }
                         deferred.reject(new Error('TokenExpired'));
                     } else {
                         deferred.reject(err);


### PR DESCRIPTION
This ensure client disconnects after an expired token and also make sure the server only emit the token-expired event once. 

This issue should be revised though!