### PR TITLE
Add option for plugin_bin to connect to storage via server

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,5 +260,6 @@ exports.getGmeConfig = function () {
 };
 
 exports.getComponentsJson = webgmeUtils.getComponentsJson;
+exports.utils = webgmeUtils;
 
 module.exports = exports;

--- a/src/bin/run_plugin.js
+++ b/src/bin/run_plugin.js
@@ -74,6 +74,7 @@ main = function (argv, callback) {
             console.log('    $ node run_plugin.js MinimalWorkingExample TestProject -w plugin-blobs');
             console.log('    $ node run_plugin.js MinimalWorkingExample TestProject -b b1 -c ' +
                 '#def8861ca16237e6756ee22d27678d979bd2fcde');
+            console.log('    $ node run_plugin.js PluginGenerator TestProject --serverUrl http://localhost:8888');
             console.log();
             console.log('  Plugin paths using ' + configDir + path.sep + 'config.' + env + '.js :');
             console.log();
@@ -163,14 +164,16 @@ main = function (argv, callback) {
             if (program.serverUrl) {
                 logger.info('serverUrl was specified "', program.serverUrl, '" will request token for user.');
 
-                webgme.requestWebGMEToken(gmeConfig, userName, program.user.split[':'][1], program.serverUrl)
+                webgme.utils.requestWebGMEToken(gmeConfig, userName, program.user.split(':')[1], program.serverUrl)
                     .then(function (token) {
                         var WorkerRequests = require('../server/worker/workerrequests'),
                             wr = new WorkerRequests(logger, gmeConfig, program.serverUrl);
-                        context.pluginConfig = pluginConfig;
-                        context.project = project.getProjectId();
-
-                        wr.executePlugin(token, undefined, pluginName, context,
+                        context.project = project.projectId;
+                        wr.executePlugin(token, undefined, pluginName,
+                            {
+                                managerConfig: context,
+                                pluginConfig: pluginConfig,
+                            },
                             function (err_, pluginResult_) {
                                 err = err_;
                                 pluginResult = pluginResult_;

--- a/src/bin/run_plugin.js
+++ b/src/bin/run_plugin.js
@@ -50,8 +50,9 @@ main = function (argv, callback) {
             'Namespace the plugin should run under.', '')
         .option('-m, --mongo-database-uri [url]',
             'URI of the MongoDB [default from the configuration file]', gmeConfig.mongo.uri)
-        .option('-u, --user [string]', 'the user of the command [if not given we use the default user]',
-            gmeConfig.authentication.guestAccount)
+        .option('-u, --user [string]', 'the user of the command [if not given we use the default user]. Note that if ' +
+            'this is used together with the --serverUrl option the password can be provided by adding a semicolon.',
+        gmeConfig.authentication.guestAccount)
         .option('-o, --owner [string]', 'the owner of the project [by default, the user is the owner]')
         .option('-w, --writeBlobFilesDir [string]',
             'If defined will also write blob-files to %cwd%/%writeBlobFilesDir%')

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -3574,6 +3574,14 @@ define([
          *
          * @param {module:Core~Node} node - the node in question.
          * @param {string} path - the path of the mixin node.
+         * @return {object} - Returns and object with isOk set to true if the given path can be added as a
+         * mixin to the given node. If it cannot, the reason will be reported under reason.
+         *
+         * @example
+         * result = core.canSetAsMixin(node, core.getPath(aValidMixinNode));
+         * // result = { isOk: true, reason: '' }
+         * result = core.canSetAsMixin(node, core.getPath(node));
+         * // result = { isOk: false, reason: 'Node cannot be mixin of itself!' }
          *
          * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
          * @throws {CoreAssertError} If some internal error took place inside the core layers.

--- a/src/server/worker/workerrequests.js
+++ b/src/server/worker/workerrequests.js
@@ -251,8 +251,6 @@ function WorkerRequests(mainLogger, gmeConfig, webgmeUrl) {
                         data.originalSocketId = socketId;
                         storage.sendNotification(data, callback);
                     }];
-                } else {
-                    logger.warn('No socketId provided for plugin execution - notifications NOT available.');
                 }
 
                 pluginManager.projectAccess = res.access;

--- a/test/bin/run_plugin.spec.js
+++ b/test/bin/run_plugin.spec.js
@@ -1,6 +1,7 @@
 /*eslint-env node, mocha*/
 /**
  * @author lattmann / https://github.com/lattmann
+ * @author pmeijer / https://github.com/pmeijer
  */
 
 
@@ -112,35 +113,35 @@ describe('Run plugin CLI', function () {
 
         it('should run the Minimal Working Example plugin and return with error in plugin-result', function (done) {
             runPlugin.main(['node', filename, 'MinimalWorkingExample', projectName,
-                '-j', './test/bin/run_plugin/MinimalWorkingExample.config.json'],
-            function (err, pluginResult) {
-                if (err) {
-                    done(err);
-                    return;
-                }
+                    '-j', './test/bin/run_plugin/MinimalWorkingExample.config.json'],
+                function (err, pluginResult) {
+                    if (err) {
+                        done(err);
+                        return;
+                    }
 
-                if (pluginResult.success === true) {
-                    done(new Error('should have failed to run plugin'));
-                } else {
-                    expect(pluginResult.error).to.include('Failed on purpose');
-                    done();
+                    if (pluginResult.success === true) {
+                        done(new Error('should have failed to run plugin'));
+                    } else {
+                        expect(pluginResult.error).to.include('Failed on purpose');
+                        done();
+                    }
                 }
-            }
             );
         });
 
         it('should run the Minimal Working Example plugin if owner is specified', function (done) {
             runPlugin.main(['node', filename, 'MinimalWorkingExample', projectName,
-                '-o', gmeConfig.authentication.guestAccount],
-            function (err, result) {
-                if (err) {
-                    done(new Error(err));
-                    return;
+                    '-o', gmeConfig.authentication.guestAccount],
+                function (err, result) {
+                    if (err) {
+                        done(new Error(err));
+                        return;
+                    }
+                    expect(result.success).to.equal(true);
+                    expect(result.error).to.equal(null);
+                    done();
                 }
-                expect(result.success).to.equal(true);
-                expect(result.error).to.equal(null);
-                done();
-            }
             );
         });
 
@@ -234,5 +235,32 @@ describe('Run plugin CLI', function () {
             });
         });
 
+        it('should run and connect to server when serverUrl specified', function (done) {
+            var webGME = testFixture.WebGME,
+                gmeConfig = testFixture.getGmeConfig(),
+                error,
+                server;
+
+            server = webGME.standaloneServer(gmeConfig);
+
+            Q.ninvoke(server, 'start')
+                .then(function () {
+                    return runPlugin.main([
+                        'node', filename, 'MinimalWorkingExample', projectName, '-l',
+                        'http://127.0.0.1:' + gmeConfig.server.port]);
+                })
+                .then(function (result) {
+                    expect(result.success).to.equal(true);
+                    expect(result.error).to.equal(null);
+                })
+                .catch(function (err) {
+                    error = err;
+                })
+                .finally(function () {
+                    server.stop(function (err2) {
+                        done(error || err2);
+                    });
+                });
+        });
     });
 });

--- a/test/bin/run_plugin.spec.js
+++ b/test/bin/run_plugin.spec.js
@@ -113,35 +113,35 @@ describe('Run plugin CLI', function () {
 
         it('should run the Minimal Working Example plugin and return with error in plugin-result', function (done) {
             runPlugin.main(['node', filename, 'MinimalWorkingExample', projectName,
-                    '-j', './test/bin/run_plugin/MinimalWorkingExample.config.json'],
-                function (err, pluginResult) {
-                    if (err) {
-                        done(err);
-                        return;
-                    }
-
-                    if (pluginResult.success === true) {
-                        done(new Error('should have failed to run plugin'));
-                    } else {
-                        expect(pluginResult.error).to.include('Failed on purpose');
-                        done();
-                    }
+                '-j', './test/bin/run_plugin/MinimalWorkingExample.config.json'],
+            function (err, pluginResult) {
+                if (err) {
+                    done(err);
+                    return;
                 }
+
+                if (pluginResult.success === true) {
+                    done(new Error('should have failed to run plugin'));
+                } else {
+                    expect(pluginResult.error).to.include('Failed on purpose');
+                    done();
+                }
+            }
             );
         });
 
         it('should run the Minimal Working Example plugin if owner is specified', function (done) {
             runPlugin.main(['node', filename, 'MinimalWorkingExample', projectName,
-                    '-o', gmeConfig.authentication.guestAccount],
-                function (err, result) {
-                    if (err) {
-                        done(new Error(err));
-                        return;
-                    }
-                    expect(result.success).to.equal(true);
-                    expect(result.error).to.equal(null);
-                    done();
+                '-o', gmeConfig.authentication.guestAccount],
+            function (err, result) {
+                if (err) {
+                    done(new Error(err));
+                    return;
                 }
+                expect(result.success).to.equal(true);
+                expect(result.error).to.equal(null);
+                done();
+            }
             );
         });
 


### PR DESCRIPTION
By specifying `--serverUrl` the plugin will connect to the storage via the server. The main difference is that changes will be broadcast to connected clients and the execution environment is more similar to when executing a plugin on the server.

To run:
`node run_plugin.js PluginGenerator TestProject --serverUrl http://localhost:8888'`