### PR TITLE
Get library root id for GMENode

### DIFF
--- a/src/client/gmeNodeGetter.js
+++ b/src/client/gmeNodeGetter.js
@@ -595,6 +595,11 @@ define([], function () {
         };
     };
 
+    GMENode.prototype.getLibraryRootId = function (name) {
+        return this._storeNode(this._state.core.getLibraryRoot(this._state.nodes[this._id].node, name));
+    };
+
+
     // GetNode from another node...
     GMENode.prototype.getNode = function (id) {
         if (this._state.nodes[id]) {

--- a/src/docs/client.getter.doc.js
+++ b/src/docs/client.getter.doc.js
@@ -297,7 +297,7 @@
  * @instance
  * @param {string} baseId - Id to the base node we want to check.
  *
- * @return {bool} Returns true if the base is on the inheritance chain of node. A node is considered to be an 
+ * @return {bool} Returns true if the base is on the inheritance chain of node. A node is considered to be an
  * instance of itself here.
  */
 
@@ -318,6 +318,16 @@
  * @param {string | null | undefined} base - the new base.
  *
  * @return {boolean} True if the supplied base is a valid base for the node.
+ */
+
+/**
+ * @description Returns the Id of the root of the library in question.
+ * @function getLibraryRootId
+ * @memberOf GMENode
+ * @param {string} name - the name of the library.
+ *
+ * @return {string | null} If the library is found then the return value will be the Id of its root,
+ * otherwise the function returns null.
  */
 
 // expect(typeof node.getRegistryNames).to.equal('function');

--- a/test/client/js/client/gmeNodeGetter.spec.js
+++ b/test/client/js/client/gmeNodeGetter.spec.js
@@ -174,6 +174,7 @@ describe('gmeNodeGetter', function () {
         expect(typeof node.isReadOnly).to.equal('function');
         expect(typeof node.getCommonBaseId).to.equal('function');
         expect(typeof node.getCommonParentId).to.equal('function');
+        expect(typeof node.getLibraryRootId).to.equal('function');
     });
 
     it('should return the parentId', function () {
@@ -876,5 +877,11 @@ describe('gmeNodeGetter', function () {
 
         expect(!!threw).to.equal(true);
         expect(threw.message).to.include('is not a valid node');
+    });
+
+    it('should return null at getLibraryRootId without proper libraryName', function () {
+        var node = getNode('', logger, basicState, basicStoreNode);
+
+        expect(node.getLibraryRootId('mope')).to.equal(null);
     });
 });


### PR DESCRIPTION
As the META info is readily available, any GMENode should be able to ask for the id of the root of any known library by name.