### PR TITLE
Make sure gmeConfig is loaded correctly in classes.build

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -14,6 +14,8 @@
     <meta property="og:url" content="<%=url%>"/>
     <meta property="og:image" content="<%=imageUrl%>"/>
 
+    <meta id="mounted-path" content="<%=mountedPath%>"/>
+
     <script type="text/javascript">
         var myInit = function () {
             console.log('myInit function was called');

--- a/utils/build/webgme.classes/webgme.classes.js
+++ b/utils/build/webgme.classes/webgme.classes.js
@@ -141,15 +141,24 @@ define('webgme.classes', [
         // eslint-disable-next-line
         docReady(function () {
             somethingFinishedLoading();
+            requestGmeConfig();
         });
     } else {
         somethingFinishedLoading();
+        requestGmeConfig();
     }
 
-
-    (function getGmeConfig() {
+    function requestGmeConfig() {
         var http = new XMLHttpRequest(),
-            configUrl = window.location.origin + '/gmeConfig.json';
+            mountPath = '',
+            mountElm = document.getElementById('mounted-path'),
+            configUrl;
+
+        if (mountElm && mountElm.getAttribute('content')) {
+            mountPath = mountElm.getAttribute('content');
+        }
+
+        configUrl = window.location.origin + mountPath + '/gmeConfig.json';
         http.onreadystatechange = function () {
             if (http.readyState === 4 && http.status === 200) {
                 GME.gmeConfig = JSON.parse(http.responseText);
@@ -161,5 +170,5 @@ define('webgme.classes', [
         };
         http.open('GET', configUrl, true);
         http.send();
-    })();
+    }
 });


### PR DESCRIPTION
The index file served at `/`, `/index.html` should now contain an element with `id="mounted-path"` and content as shown below in order for the webgme classes to be able to resolve the mountedPath for obtaining the gme config.

(This only applies when the webgme app is mounted at non-root.)

```
<meta id="mounted-path" content="<%=mountedPath%>"/>
```