### PR TITLE
Add api/plugin/:pluginId/run endpoint for short running plugins

### DIFF
--- a/config/validator.js
+++ b/config/validator.js
@@ -237,16 +237,15 @@ function validateConfig(configOrFileName) {
         assertString('config.seedProjects.createAtStartup[' + index + '].seedId',
             config.seedProjects.createAtStartup[index].seedId);
         assertString('config.seedProjects.createAtStartup[' + index + '].projectName', seedInfo.projectName);
-        assertObject('config.seedProjects.createAtStartup[' + index + '].rights', seedInfo.rights);
+        assertObject('config.seedProjects.createAtStartup[' + index + '].rights', seedInfo.rights, true);
         if (seedInfo.creatorId) {
             assertString('config.seedProjects.createAtStartup[' + index + '].creatorId', seedInfo.creatorId);
         } else if (typeof config.authentication.adminAccount !== 'string') {
             throw new Error('Either config.seedProjects.createAtStartup[' + index +
                 '].creatorId or config.authentication.adminAccount should exists!');
         }
-        if (seedInfo.ownerId) {
-            assertString('config.seedProjects.createAtStartup[' + index + '].ownerId', seedInfo.ownerId);
-        }
+
+        assertString('config.seedProjects.createAtStartup[' + index + '].ownerId', seedInfo.ownerId, true);
     });
 
     // server configuration

--- a/src/plugin/coreplugins/PluginGenerator/plugin_bindings_js.ejs
+++ b/src/plugin/coreplugins/PluginGenerator/plugin_bindings_js.ejs
@@ -97,7 +97,7 @@ define([
             });
 
             childProc.on('error', (err) => {
-                deferred.resolve(err);
+                logger.error(err);
             });
 
             return deferred.promise;

--- a/src/plugin/coreplugins/PluginGenerator/plugin_bindings_js.ejs
+++ b/src/plugin/coreplugins/PluginGenerator/plugin_bindings_js.ejs
@@ -11,20 +11,22 @@ define([
     'q',
     'plugin/PluginConfig',
     'text!./metadata.json',
-    'plugin/PluginBase'
+    'plugin/PluginBase',
+    'module'
 ], function (
     Q,
     PluginConfig,
     pluginMetadata,
-    PluginBase) {
+    PluginBase,
+    module) {
     'use strict';
 
     pluginMetadata = JSON.parse(pluginMetadata);
-
+    const path = require('path');
     // Modify these as needed..
     const START_PORT = 5555;
     const COMMAND = '<%= command %>';
-    const SCRIPT_FILE = 'src/plugins/<%= pluginID %>/<%= scriptFile %>';
+    const SCRIPT_FILE = path.join(path.dirname(module.uri), '<%= scriptFile %>');
 
     /**
      * Initializes a new instance of PythonBindings.
@@ -97,7 +99,7 @@ define([
             });
 
             childProc.on('error', (err) => {
-                logger.error(err);
+                deferred.reject(err);
             });
 
             return deferred.promise;

--- a/src/server/api/webgme-api-plugin-execute-post.json
+++ b/src/server/api/webgme-api-plugin-execute-post.json
@@ -1,5 +1,4 @@
 {
-    "pluginId": "ExportImport",
     "projectId": "guest+MyProject",
     "branchName": "master"
 }

--- a/src/server/api/webgme-api-plugin-run.json
+++ b/src/server/api/webgme-api-plugin-run.json
@@ -1,0 +1,18 @@
+{
+  "success": true,
+  "messages": [],
+  "commits": [
+    {
+      "commitHash": "#f8af7999fd95efbddb7f7b4fc9446f0dac2e33c6",
+      "branchName": "master",
+      "status": "SYNCED"
+    }
+  ],
+  "artifacts": [
+    "da47ded7c3391fc46cd84752c829fc383649bc94"
+  ],
+  "pluginName": "Export, Import and Update Library",
+  "startTime": "2015-09-24T21:44:16.456Z",
+  "finishTime": "2015-09-24T21:45:02.047Z",
+  "error": null
+}

--- a/src/server/api/webgme-api.raml
+++ b/src/server/api/webgme-api.raml
@@ -785,8 +785,19 @@ resourceTypes:
           200:
             body:
               application/json:
-                example: !include webgme-api-plugin-execute.json   
-    
+                example: !include webgme-api-plugin-execute.json
+    /run:
+      post:
+        description: Runs a plugin on the server side and waits for it to finish.
+        body:
+          application/json:
+            example: !include webgme-api-plugin-execute-post.json   
+        
+        responses:
+          200:
+            body:
+              application/json:
+                example: !include webgme-api-plugin-run.json  
     /results/{resultId}:
       get:
         description: Gets a result for this plugin by resultId.

--- a/src/utils.js
+++ b/src/utils.js
@@ -543,13 +543,14 @@ function createStartUpProjects(gmeConfig, gmeAuth, storage, logger, url) {
             createdProjects.forEach(function (projectInfo) {
                 var userOrOrg,
                     id = storageUtils.getProjectIdFromOwnerIdAndProjectName(projectInfo.ownerId,
-                        projectInfo.projectName);
+                        projectInfo.projectName),
+                    rights = projectInfo.rights || {};
 
-                for (userOrOrg in projectInfo.rights) {
+                for (userOrOrg in rights) {
                     logger.info('Authorizing \'' + userOrOrg + '\' to use \'' + projectInfo.projectName +
                         '\' of \'' + projectInfo.ownerId + '.');
                     authorizationRequests.push(gmeAuth.authorizer.setAccessRights(userOrOrg,
-                        id, projectInfo.rights[userOrOrg], projectAuthParams));
+                        id, rights[userOrOrg], projectAuthParams));
                 }
             });
 

--- a/test/server/api/plugin/plugin.spec.js
+++ b/test/server/api/plugin/plugin.spec.js
@@ -391,7 +391,6 @@ describe('PLUGIN REST API', function () {
             it('should execute ExportImport [pluginId, projectId, branchName]' +
                 ' /api/plugin/ConfigurationArtifact/execute', function (done) {
                 var requestBody = {
-                    pluginId: 'ConfigurationArtifact',
                     projectId: importResult.project.projectId,
                     branchName: 'master'
                 };
@@ -507,8 +506,9 @@ describe('PLUGIN REST API', function () {
             it('should 404 when ExportImport [pluginId, projectId, branchName] /api/plugin/ExportImport/execute ' +
                 'and timeout passed /api/v1/plugin/ExportImport/results/%RESULT_ID%', function (done) {
                 var requestBody = {
-                    pluginId: 'ExportImport',
+                    //pluginId: 'ExportImport',
                     projectId: importResult.project.projectId,
+                    branchName: 'master',
                     pluginConfig: {
                         type: 'Import'
                     }
@@ -556,6 +556,52 @@ describe('PLUGIN REST API', function () {
                         }, 100);
                     });
             });
+
+            it('should 200 at /api/plugin/MinimalWorkingExample/run and return results', function (done) {
+                agent.post(server.getUrl() + '/api/v1/plugin/MinimalWorkingExample/run')
+                    .send({
+                        projectId: importResult.project.projectId,
+                        branchName: 'master',
+                        pluginConfig: {
+                            save: false,
+                        }
+                    })
+                    .end(function (err, res) {
+                        try {
+                            expect(err).to.equal(null);
+                            expect(res.status).to.equal(200);
+                            expect(res.body.success).to.equal(true);
+                            expect(res.body.pluginId).to.equal('MinimalWorkingExample');
+                            done();
+                        } catch (e) {
+                            done(e);
+                        }
+                    });
+            });
+
+            it('should 200 at /api/plugin/MinimalWorkingExample/run and return results (success=false)',
+                function (done) {
+                    agent.post(server.getUrl() + '/api/v1/plugin/MinimalWorkingExample/run')
+                        .send({
+                            projectId: importResult.project.projectId,
+                            branchName: 'master',
+                            pluginConfig: {
+                                shouldFail: true,
+                            }
+                        })
+                        .end(function (err, res) {
+                            try {
+                                expect(err).to.equal(null);
+                                expect(res.status).to.equal(200);
+                                expect(res.body.success).to.equal(false);
+                                expect(res.body.pluginId).to.equal('MinimalWorkingExample');
+                                done();
+                            } catch (e) {
+                                done(e);
+                            }
+                        });
+                }
+            );
         });
     });
 });


### PR DESCRIPTION
Use the **/execute for long running plugins where a result-id for polling for the finished result is returned immediately.