### PR TITLE
Major speed-ups in complex meta-query methods by introducing temporary cache

### DIFF
--- a/src/client/gmeNodeGetter.js
+++ b/src/client/gmeNodeGetter.js
@@ -375,7 +375,8 @@ define([], function () {
                 children: [],
                 sensitive: !noFilter,
                 multiplicity: false,
-                aspect: aspect
+                aspect: aspect,
+                cache: {}
             },
             fullList,
             filteredList,

--- a/src/client/gmeNodeGetter.js
+++ b/src/client/gmeNodeGetter.js
@@ -400,12 +400,18 @@ define([], function () {
     GMENode.prototype.getValidChildrenMetaIds = function (parameters) {
         var coreParams = {
                 node: this._state.nodes[this._id].node,
-                sensitive: parameters.sensitive,
-                aspect: parameters.aspect,
                 cache: parameters.cache || {}
             },
             self = this,
             i;
+
+        if (parameters.sensitive) {
+            coreParams.sensitive = parameters.sensitive;
+        }
+
+        if (parameters.aspect) {
+            coreParams.aspect = parameters.aspect;
+        }
 
         if (parameters.childrenIds && parameters.multiplicity) {
             coreParams.multiplicity = true;
@@ -458,11 +464,14 @@ define([], function () {
         var coreParams = {
                 node: this._state.nodes[this._id].node,
                 name: parameters.name,
-                sensitive: parameters.sensitive,
                 cache: parameters.cache || {}
             },
             self = this,
             i;
+
+        if (parameters.sensitive) {
+            coreParams.sensitive = parameters.sensitive;
+        }
 
         if (parameters.memberIds && parameters.multiplicity) {
             coreParams.multiplicity = true;

--- a/src/client/gmeNodeGetter.js
+++ b/src/client/gmeNodeGetter.js
@@ -371,81 +371,116 @@ define([], function () {
 
     GMENode.prototype.getValidChildrenTypesDetailed = function (aspect, noFilter) {
         var parameters = {
-                node: this._state.nodes[this._id].node,
-                children: [],
+                childrenIds: this.getChildrenIds(),
                 sensitive: !noFilter,
                 multiplicity: false,
                 aspect: aspect,
                 cache: {}
             },
+            result = {},
             fullList,
             filteredList,
-            validTypes = {},
-            keys = this.getChildrenIds(),
             i;
 
-        for (i = 0; i < keys.length; i++) {
-            if (this._state.nodes[keys[i]]) {
-                parameters.children.push(this._state.nodes[keys[i]].node);
-            } else {
-                this._logger.warn('Child node, ' + keys[i] + ', not loaded at getValidChildrenTypes' +
-                    'Detailed invocation - cardinality constraints will not be enforced properly.');
-            }
-        }
-
-        fullList = this._state.core.getValidChildrenMetaNodes(parameters);
-
+        fullList = this.getValidChildrenMetaIds(parameters);
         parameters.multiplicity = true;
-        filteredList = this._state.core.getValidChildrenMetaNodes(parameters);
+        filteredList = this.getValidChildrenMetaIds(parameters);
 
         for (i = 0; i < fullList.length; i += 1) {
-            validTypes[this._state.core.getPath(fullList[i])] = false;
+            result[fullList[i]] = false;
         }
 
         for (i = 0; i < filteredList.length; i += 1) {
-            validTypes[this._state.core.getPath(filteredList[i])] = true;
+            result[filteredList[i]] = true;
         }
 
-        return validTypes;
+        return result;
+    };
+
+    GMENode.prototype.getValidChildrenMetaIds = function (parameters) {
+        var coreParams = {
+                node: this._state.nodes[this._id].node,
+                sensitive: parameters.sensitive,
+                aspect: parameters.aspect,
+                cache: parameters.cache || {}
+            },
+            self = this,
+            i;
+
+        if (parameters.childrenIds && parameters.multiplicity) {
+            coreParams.multiplicity = true;
+            coreParams.children = [];
+            for (i = 0; i < parameters.childrenIds.length; i++) {
+                if (this._state.nodes[parameters.childrenIds[i]]) {
+                    coreParams.children.push(this._state.nodes[parameters.childrenIds[i]].node);
+                } else {
+                    this._logger.warn('Child node [' + parameters.childrenIds[i] + '] not loaded at ' +
+                        'getValidChildrenMetaIds - cardinality constraints will not be enforced properly.');
+                }
+            }
+        }
+
+        return this._state.core.getValidChildrenMetaNodes(coreParams)
+            .map(function (coreNode) {
+                return self._state.core.getPath(coreNode);
+            });
     };
 
     GMENode.prototype.getValidSetMemberTypesDetailed = function (setName) {
         var parameters = {
                 node: this._state.nodes[this._id].node,
-                members: [],
+                memberIds: this.getMemberIds(setName),
                 sensitive: true,
                 multiplicity: false,
                 name: setName
             },
+            result = {},
             fullList,
             filteredList,
-            validTypes = {},
-            keys = this.getMemberIds(setName),
             i;
 
-        for (i = 0; i < keys.length; i++) {
-            if (this._state.nodes[keys[i]]) {
-                parameters.members.push(this._state.nodes[keys[i]].node);
-            } else {
-                this._logger.warn('Member node, ' + keys[i] + ', not loaded at getValidSetMemberTypes' +
-                    'Detailed invocation - cardinality constraints will not be enforced properly.');
-            }
-        }
-
-        fullList = this._state.core.getValidSetElementsMetaNodes(parameters);
-
+        fullList = this.getValidSetElementsMetaIds(parameters);
         parameters.multiplicity = true;
-        filteredList = this._state.core.getValidSetElementsMetaNodes(parameters);
+        filteredList = this.getValidSetElementsMetaIds(parameters);
 
         for (i = 0; i < fullList.length; i += 1) {
-            validTypes[this._state.core.getPath(fullList[i])] = false;
+            result[fullList[i]] = false;
         }
 
         for (i = 0; i < filteredList.length; i += 1) {
-            validTypes[this._state.core.getPath(filteredList[i])] = true;
+            result[filteredList[i]] = true;
         }
 
-        return validTypes;
+        return result;
+    };
+
+    GMENode.prototype.getValidSetElementsMetaIds = function (parameters) {
+        var coreParams = {
+                node: this._state.nodes[this._id].node,
+                name: parameters.name,
+                sensitive: parameters.sensitive,
+                cache: parameters.cache || {}
+            },
+            self = this,
+            i;
+
+        if (parameters.memberIds && parameters.multiplicity) {
+            coreParams.multiplicity = true;
+            coreParams.members = [];
+            for (i = 0; i < parameters.memberIds.length; i++) {
+                if (this._state.nodes[parameters.memberIds[i]]) {
+                    coreParams.members.push(this._state.nodes[parameters.memberIds[i]].node);
+                } else {
+                    this._logger.warn('Member node [' + parameters.memberIds[i] + '] not loaded at ' +
+                        'getValidSetElementsMetaIds - cardinality constraints will not be enforced properly.');
+                }
+            }
+        }
+
+        return this._state.core.getValidSetElementsMetaNodes(coreParams)
+            .map(function (coreNode) {
+                return self._state.core.getPath(coreNode);
+            });
     };
 
     GMENode.prototype.getMetaTypeId = GMENode.prototype.getBaseTypeId = function () {

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -3337,11 +3337,12 @@ define([
          * Retrieves the valid META nodes that can be base of a child of the node.
          * @param {object} parameters - the input parameters of the query.
          * @param {module:Core~Node} parameters.node - the node in question.
-         * @param {module:Core~Node[]} [parameters.children] - the current children of the node in question.
          * @param {bool} [parameters.sensitive=false] - if true, the query filters out the abstract and connection-like
          * nodes.
          * @param {bool} [parameters.multiplicity=false] - if true, the query tries to filter out even more
-         * nodes according to the multiplicity rules (the check is only meaningful if all the children were passed)
+         * nodes according to the multiplicity rules.
+         * @param {module:Core~Node[]} [parameters.children=[]] - the current children of the node in question
+         * (must be passed if multiplicity=true)
          * @param {string|null} [parameters.aspect=undefined] - if given, the query filters to contain only types that
          * are visible in the given aspect.
          * @return {module:Core~Node[]} The function returns a list of valid nodes that can be instantiated as a
@@ -3377,11 +3378,11 @@ define([
          * @param {object} parameters - the input parameters of the query.
          * @param {module:Core~Node} parameters.node - the node in question.
          * @param {string} parameters.name - the name of the set.
-         * @param {module:Core~Node[]} [parameters.members] - the current members of the set of the node in question.
          * @param {bool} [parameters.sensitive=false] - if true, the query filters out the abstract and connection-like
          * nodes.
          * @param {bool} [parameters.multiplicity=false] - if true, the query tries to filter out even more nodes
          * according to the multiplicity rules (the check is only meaningful if all the members were passed)
+         * @param {module:Core~Node[]} [parameters.members=[]] - the current members of the set of the node in question.
          *
          * @return {module:Core~Node[]} The function returns a list of valid nodes that can be instantiated as a
          * member of the set of the node.

--- a/src/common/core/metaquerycore.js
+++ b/src/common/core/metaquerycore.js
@@ -60,13 +60,14 @@ define([
                 i, j,
                 typeCounters = {},
                 children = parameters.children || [],
+                cache = parameters.cache || {},
                 rules,
                 inAspect;
 
             rules = innerCore.getChildrenMeta(node) || {};
 
             for (i = 0; i < keys.length; i += 1) {
-                if (self.isValidChildOf(metaNodes[keys[i]], node)) {
+                if (innerCore.isValidChildOf(metaNodes[keys[i]], node, cache)) {
                     validNodes.push(metaNodes[keys[i]]);
                 }
             }

--- a/src/common/core/metaquerycore.js
+++ b/src/common/core/metaquerycore.js
@@ -57,6 +57,7 @@ define([
                 node = parameters.node,
                 metaNodes = self.getAllMetaNodes(node),
                 keys = Object.keys(metaNodes || {}),
+                validChildren = innerCore.getValidChildrenPaths(node),
                 i, j,
                 typeCounters = {},
                 children = parameters.children || [],
@@ -67,8 +68,10 @@ define([
             rules = innerCore.getChildrenMeta(node) || {};
 
             for (i = 0; i < keys.length; i += 1) {
-                if (innerCore.isValidChildOf(metaNodes[keys[i]], node, cache)) {
-                    validNodes.push(metaNodes[keys[i]]);
+                for (j = 0; j < validChildren.length; j += 1) {
+                    if (innerCore.isTypeOf(metaNodes[keys[i]], validChildren[j], cache)) {
+                        validNodes.push(metaNodes[keys[i]]);
+                    }
                 }
             }
 

--- a/src/common/core/mixincore.js
+++ b/src/common/core/mixincore.js
@@ -389,10 +389,11 @@ define([
 
             cache = cache || cache;
 
-            // FIXME: Isn' this covered by the logic below?
-            // if (innerCore.isValidChildOf(node, parentNode)) {
-            //     return true;
-            // }
+            // TODO: this is only needed when the containment definition is outside of meta..
+            // TODO: (That is when it's defined between non-meta nodes)
+            if (innerCore.isValidChildOf(node, parentNode)) {
+                return true;
+            }
 
             // Now we have to look deeper as containment rule may come from a mixin
             childrenPaths = self.getValidChildrenPaths(parentNode, cache);
@@ -416,10 +417,11 @@ define([
                 metaNodes,
                 i;
 
-            // FIXME: Isn' this covered by the logic below?
-            // if (innerCore.isValidTargetOf(node, source, name)) {
-            //     return true;
-            // }
+            // TODO: this is only needed when the set/pointer definition is outside of meta..
+            // TODO: (That is when it's defined between non-meta nodes)
+            if (innerCore.isValidTargetOf(node, source, name)) {
+                return true;
+            }
 
             // Now we have to look deeper as pointer rule may come from a mixin
             targetPaths = self.getValidTargetPaths(source, name);

--- a/src/common/core/mixincore.js
+++ b/src/common/core/mixincore.js
@@ -456,10 +456,12 @@ define([
         };
 
         this.getValidPointerNames = function (node) {
+            //console.count('getValidPointerNames');
             return getValidNames(node, innerCore.getOwnValidPointerNames, {});
         };
 
         this.getValidSetNames = function (node) {
+            //console.count('getValidSetNames');
             return getValidNames(node, innerCore.getOwnValidSetNames, {});
         };
 
@@ -472,6 +474,7 @@ define([
         };
 
         this.getValidAspectNames = function (node) {
+            //console.count('getValidAspectNames');
             return getValidNames(node, innerCore.getOwnValidAspectNames, {});
         };
 

--- a/src/common/core/mixincore.js
+++ b/src/common/core/mixincore.js
@@ -416,9 +416,10 @@ define([
                 metaNodes,
                 i;
 
-            if (innerCore.isValidTargetOf(node, source, name)) {
-                return true;
-            }
+            // FIXME: Isn' this covered by the logic below?
+            // if (innerCore.isValidTargetOf(node, source, name)) {
+            //     return true;
+            // }
 
             // Now we have to look deeper as pointer rule may come from a mixin
             targetPaths = self.getValidTargetPaths(source, name);

--- a/test/client/js/client/gmeNodeGetter.spec.js
+++ b/test/client/js/client/gmeNodeGetter.spec.js
@@ -160,6 +160,8 @@ describe('gmeNodeGetter', function () {
         expect(typeof node.getCrosscutsInfo).to.equal('function');
         expect(typeof node.getValidChildrenTypesDetailed).to.equal('function');
         expect(typeof node.getValidSetMemberTypesDetailed).to.equal('function');
+        expect(typeof node.getValidChildrenMetaIds).to.equal('function');
+        expect(typeof node.getValidSetElementsMetaIds).to.equal('function');
         expect(typeof node.getMetaTypeId).to.equal('function');
         expect(typeof node.isMetaNode).to.equal('function');
         expect(typeof node.isTypeOf).to.equal('function');
@@ -698,7 +700,10 @@ describe('gmeNodeGetter', function () {
     });
 
     it('should return a detailed information about valid children types of the node', function () {
-        var node = getNode('', logger, basicState, basicStoreNode);
+        var node = getNode('', logger, basicState, basicStoreNode),
+            res = ['/1', '/175547009', '/175547009/1104061497', '/175547009/1817665259', '/175547009/471466181',
+                '/175547009/871430202'];
+
 
         expect(node.getValidChildrenTypesDetailed(null, false)).to.eql({
             '/1': true,
@@ -718,13 +723,20 @@ describe('gmeNodeGetter', function () {
             '/175547009/871430202': true
         });
 
+        expect(node.getValidChildrenMetaIds({nodeId: node.getId()})).to.have.members(res);
+
         expect(node.getValidChildrenTypesDetailed('any', false)).to.eql({});
+        expect(node.getValidChildrenMetaIds({nodeId: node.getId(), aspect: 'any'})).to.deep.equal([]);
     });
 
     it('should return a detailed information about valid member types of the set of the node', function () {
         var node = getNode('/1303043463/2119137141', logger, basicState, basicStoreNode);
 
         expect(node.getValidSetMemberTypesDetailed('setPtr')).to.eql({'/175547009/871430202': true});
+        expect(node.getValidSetElementsMetaIds({
+            nodeId: node.getId(),
+            name: 'setPtr'
+        })).to.deep.eql(['/175547009/871430202']);
     });
 
     it('should return the id of the meta type of the node', function () {

--- a/test/common/core/metacore.spec.js
+++ b/test/common/core/metacore.spec.js
@@ -120,6 +120,11 @@ describe('meta core', function () {
         core.isTypeOf(attrNode, setNode).should.be.false;
     });
 
+    it('node should be isTypeOf itself', function () {
+        core.isTypeOf(attrNode, attrNode).should.be.true;
+        core.isTypeOf(attrNode, core.getPath(attrNode)).should.be.true;
+    });
+
     it('checking types using paths', function () {
         core.isTypeOf(attrNode, core.getPath(base)).should.be.true;
         core.isTypeOf(attrNode, core.getPath(setNode)).should.be.false;


### PR DESCRIPTION
This PR also exposes equivalents on the client api to the core methods:
```
getValidChildrenMetaNodes
```

```
getValidSetElementsMetaNodes
```