### PR TITLE
Queue worker requests while client has local changes that haven't reached the server

### DIFF
--- a/src/client/pluginmanager.js
+++ b/src/client/pluginmanager.js
@@ -9,8 +9,9 @@
 define([
     'plugin/managerbase',
     'blob/BlobClient',
-    'common/storage/project/project'
-], function (PluginManagerBase, BlobClient, Project) {
+    'common/storage/project/project',
+    'common/Constants',
+], function (PluginManagerBase, BlobClient, Project, CONSTANTS) {
     'use strict';
 
     var ROOT_PATH = '';
@@ -132,7 +133,11 @@ define([
                 context.managerConfig.project = context.managerConfig.project.projectId;
             }
 
-            storage.simpleRequest({command: 'executePlugin', name: pluginId, context: context}, function (err, result) {
+            storage.simpleRequest({
+                command: CONSTANTS.SERVER_WORKER_REQUESTS.EXECUTE_PLUGIN,
+                name: pluginId,
+                context: context
+            }, function (err, result) {
                 if (err) {
                     callback(err, err.result);
                 } else {

--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -54,7 +54,7 @@ define([
          * Dig out the context for the server-worker request. Needed to determine if
          * the request needs be queued on the current commit-queue.
          * @param {object} swmParams
-         * @returns {object|null} If the request contains a projectId and (branchName and/or commitHash). It
+         * @returns {object} If the request contains a projectId and (branchName and/or commitHash). It
          * will return an object with projectId and (branchName and/or commitHash).
          */
         function extractSWMContext(swmParams) {
@@ -63,10 +63,9 @@ define([
             if (swmParams.projectId) {
                 result.projectId = swmParams.projectId;
                 if (swmParams.branchName || swmParams.branch || swmParams.commitHash || swmParams.commit) {
+                    // Add any of these.
                     result.branchName = swmParams.branchName || swmParams.branch;
                     result.commitHash = swmParams.commitHash || swmParams.commit;
-
-                    return result;
                 }
             } else if (swmParams.context &&
                 swmParams.context.managerConfig &&
@@ -77,7 +76,7 @@ define([
                 result.branchName = swmParams.context.managerConfig.branchName;
             }
 
-            return null;
+            return result;
         }
 
         this.open = function (networkHandler) {
@@ -543,7 +542,7 @@ define([
                 deferred,
                 queuedInBranch;
 
-            if (context && projects[context.projectId]) {
+            if (context.projectId && projects[context.projectId]) {
                 // The request deals with a currently opened project - let's see if there is
                 // a commitHash and/or branch associated with the request..
                 if (context.commitHash) {

--- a/src/common/storage/storageclasses/editorstorage.js
+++ b/src/common/storage/storageclasses/editorstorage.js
@@ -640,7 +640,7 @@ define([
                             logger.debug('_commitToBranch, commit was NOT first in queue');
                         }
                     } else {
-                        callback(new Error('Commit halted when loaded in users: ' + err));
+                        callback(new Error('Commit halted when loaded in users (proceed was not true).'));
                     }
                 });
             } else {

--- a/test/_globals.js
+++ b/test/_globals.js
@@ -67,6 +67,7 @@ var WebGME = require('../index'),
     _BlobClient,
     _Project,
     _STORAGE_CONSTANTS,
+    _CONSTANTS,
 
     _should,
     _expect,
@@ -223,6 +224,14 @@ Object.defineProperties(exports, {
                 _STORAGE_CONSTANTS = requireJS('common/storage/constants');
             }
             return _STORAGE_CONSTANTS;
+        }
+    },
+    CONSTANTS: {
+        get: function () {
+            if (!_CONSTANTS) {
+                _CONSTANTS = requireJS('common/Constants');
+            }
+            return _CONSTANTS;
         }
     },
     storageUtil: {

--- a/test/common/storage/storageclasses/editorstorage.spec.js
+++ b/test/common/storage/storageclasses/editorstorage.spec.js
@@ -105,6 +105,10 @@ describe('storage storageclasses editorstorage', function () {
                         importResult.project.createBranch('b5', importResult.commitHash),
                         importResult.project.createBranch('b6', importResult.commitHash),
                         importResult.project.createBranch('b7', importResult.commitHash),
+                        importResult.project.createBranch('b8', importResult.commitHash),
+                        importResult.project.createBranch('b9', importResult.commitHash),
+                        importResult.project.createBranch('b10', importResult.commitHash),
+                        importResult.project.createBranch('b11', importResult.commitHash),
                     ]);
                 })
                 .then(function () {
@@ -969,15 +973,24 @@ describe('storage storageclasses editorstorage', function () {
 
     // SimpleRequest queuing
 
-    function getSimpleRequestParams(commitHash) {
-        return {
+    function getSimpleRequestParams(commitHash, branchName) {
+        var params = {
             command: testFixture.CONSTANTS.SERVER_WORKER_REQUESTS.CHECK_CONSTRAINTS,
             checkType: 'META',
             includeChildren: false,
             nodePaths: ['/1'],
-            commitHash: commitHash,
             projectId: projectName2Id(projectName)
         };
+
+        if (commitHash) {
+            params.commitHash = commitHash;
+        }
+
+        if (branchName) {
+            params.branchName = branchName;
+        }
+
+        return params;
     }
 
     it('should not initiate request until queued commit was inserted at server', function (done) {
@@ -995,6 +1008,8 @@ describe('storage storageclasses editorstorage', function () {
                                 done();
                             }
                         });
+
+                        // This is needed to reduce the risk of false positives when requests weren't queued.
                         setTimeout(function () {
                             callback(null, true);
                         }, 1000);
@@ -1055,6 +1070,124 @@ describe('storage storageclasses editorstorage', function () {
                 } else {
                     // 4) close the branch
                     storage.closeBranch(projectName2Id(projectName), 'b7').catch(done);
+                }
+            });
+    });
+
+    it('should proceed as normal if referring to a commit that is not queued', function (done) {
+        // This is mainly to increase the coverage.
+        storage.openProject(projectName2Id(projectName))
+            .then(function () {
+                function hashUpdateHandler(data, commitQueue, updateQueue, callback) {
+                    if (data.local) {
+                        storage.simpleRequest(getSimpleRequestParams(originalHash), function (err) {
+                            if (err) {
+                                done(err);
+                            } else {
+                                done();
+                            }
+                        });
+
+                        callback(null, true);
+                    } else {
+                        callback(null, true);
+                    }
+                }
+
+                return storage.openBranch(projectName2Id(projectName), 'b8', hashUpdateHandler, testFixture.noop);
+            })
+            .then(function () {
+                return Q.ninvoke(storage, 'makeCommit', projectName2Id(projectName), 'b8', [originalHash],
+                    importResult.rootHash, {}, 'queued commit with no relation to the request');
+            })
+            .catch(done);
+    });
+
+    it('should queue commit when branchName and commitHash specified', function (done) {
+        storage.openProject(projectName2Id(projectName))
+            .then(function () {
+                function hashUpdateHandler(data, commitQueue, updateQueue, callback) {
+                    var params;
+
+                    if (data.local) {
+                        params = getSimpleRequestParams(data.commitData.commitObject._id, 'b9');
+                        storage.simpleRequest(params, function (err) {
+                            try {
+
+                                expect(!!err).to.equal(true);
+                                expect(err.message).to.include('Queued worker request was aborted');
+                                done();
+                            } catch (e) {
+                                done(e);
+                            }
+                        });
+
+                        callback(null, false);
+                    } else {
+                        callback(null, true);
+                    }
+                }
+
+                return storage.openBranch(projectName2Id(projectName), 'b9', hashUpdateHandler, testFixture.noop);
+            })
+            .then(function () {
+                return Q.ninvoke(storage, 'makeCommit', projectName2Id(projectName), 'b9', [originalHash],
+                    importResult.rootHash, {}, 'queued and aborted commit');
+            })
+            .catch(function (err) {
+                if (err.message.indexOf('Commit halted') < 0) {
+                    done(err);
+                } else {
+                    storage.closeBranch(projectName2Id(projectName), 'b9').catch(done);
+                }
+            });
+    });
+
+    it('should queue a plugin execution', function (done) {
+        storage.openProject(projectName2Id(projectName))
+            .then(function () {
+                function hashUpdateHandler(data, commitQueue, updateQueue, callback) {
+                    var params;
+
+                    if (data.local) {
+                        params = {
+                            command: testFixture.CONSTANTS.SERVER_WORKER_REQUESTS.EXECUTE_PLUGIN,
+                            name: 'MinimalWorkingExample',
+                            context: {
+                                managerConfig: {
+                                    project: projectName2Id(projectName),
+                                    activeNode: '',
+                                    branchName: 'b11'
+                                }
+                            }
+                        };
+                        storage.simpleRequest(params, function (err) {
+                            try {
+                                expect(!!err).to.equal(true);
+                                expect(err.message).to.include('Queued worker request was aborted');
+                                done();
+                            } catch (e) {
+                                done(e);
+                            }
+                        });
+
+                        callback(null, false);
+                    } else {
+                        callback(null, true);
+                    }
+                }
+
+                return storage.openBranch(projectName2Id(projectName), 'b11', hashUpdateHandler, testFixture.noop);
+            })
+            .then(function () {
+                return Q.ninvoke(storage, 'makeCommit', projectName2Id(projectName), 'b11', [originalHash],
+                    importResult.rootHash, {}, 'queued and aborted commit');
+            })
+            .catch(function (err) {
+                if (err.message.indexOf('Commit halted') < 0) {
+                    done(err);
+                } else {
+                    storage.closeBranch(projectName2Id(projectName), 'b11').catch(done);
                 }
             });
     });


### PR DESCRIPTION
This prevents issues with a user initiating a worker request for a specific commit (or branch and assumes that it should run at the state he/she is viewing) before the commit made it to the database at the server. 

At the point of a request the request is queued together with the queued commit (if any). If the branch/project is closed before the commits are inserted - the job is aborted too (it resolves with an error).

This fixes the issue [webgme#1632](https://github.com/webgme/webgme/issues/1632).