### PR TITLE
Fix exception when undoing to first commit made

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -1115,15 +1115,6 @@ define([
                     return;
                 }
 
-                //undo-redo
-                addModification(commitData.commitObject, clearUndoRedo);
-                self.dispatchEvent(CONSTANTS.UNDO_AVAILABLE, canUndo());
-                self.dispatchEvent(CONSTANTS.REDO_AVAILABLE, canRedo());
-                self.dispatchEvent(CONSTANTS.NEW_COMMIT_STATE, {
-                    data: data,
-                    uiState: typeof self.uiStateGetter === 'function' ? self.uiStateGetter() : null
-                });
-
                 logger.debug('loading commitHash, local?', commitHash, data.local);
                 loading(commitData.commitObject.root, commitHash, commitData.changedNodes, function (err, aborted) {
                     if (err) {
@@ -1137,6 +1128,14 @@ define([
                     } else {
                         logger.debug('loading complete for incoming rootHash', commitData.commitObject.root);
                         logState('debug', 'hashUpdateHandler');
+                        //undo-redo
+                        addModification(commitData.commitObject, clearUndoRedo);
+                        self.dispatchEvent(CONSTANTS.UNDO_AVAILABLE, canUndo());
+                        self.dispatchEvent(CONSTANTS.REDO_AVAILABLE, canRedo());
+                        self.dispatchEvent(CONSTANTS.NEW_COMMIT_STATE, {
+                            data: data,
+                            uiState: typeof self.uiStateGetter === 'function' ? self.uiStateGetter() : null
+                        });
                         callback(null, true); // proceed: true
                     }
                 });
@@ -1468,14 +1467,14 @@ define([
 
             logState('info', 'undo [before setBranchHash]');
             storage.setBranchHash(state.project.projectId, branchName, state.undoRedoChain.commitHash, state.commitHash,
-                function (err) {
+                function (err, commitResult) {
                     if (err) {
                         //TODO do we need to handle this? How?
                         callback(err);
                         return;
                     }
                     logState('info', 'undo [after setBranchHash]');
-                    callback(null);
+                    callback(null, commitResult);
                 }
             );
 
@@ -1491,14 +1490,14 @@ define([
 
             logState('info', 'redo [before setBranchHash]');
             storage.setBranchHash(state.project.projectId, branchName, state.undoRedoChain.commitHash, state.commitHash,
-                function (err) {
+                function (err, commitResult) {
                     if (err) {
                         //TODO do we need to handle this? How?
                         callback(err);
                         return;
                     }
                     logState('info', 'redo [after setBranchHash]');
-                    callback(null);
+                    callback(null, commitResult);
                 }
             );
         };

--- a/src/docs/client.doc.js
+++ b/src/docs/client.doc.js
@@ -597,6 +597,7 @@
  * @param {string} branchName - Must match the active branch.
  * @param {function} callback - Invoked when request completed.
  * @param {null|Error} callback.err - If the request failed.
+ * @param {module:Storage~CommitResult} callback.commitResult - The status of the commit made.
  * @instance
  */
 
@@ -608,6 +609,7 @@
  * @param {string} branchName - Must match the active branch.
  * @param {function} callback - Invoked when request completed.
  * @param {null|Error} callback.err - If the request failed.
+ * @param {module:Storage~CommitResult} callback.commitResult - The status of the commit made.
  * @instance
  */
 

--- a/src/plugin/PluginBase.js
+++ b/src/plugin/PluginBase.js
@@ -438,7 +438,7 @@
      * @param {string|null} message - commit message
      * @param {function} [callback] - the result callback
      * @param {null|Error} callback.err - status of the call
-     * @param {module:Storage~commitResult} callback.commitResult - status of the commit made
+     * @param {module:Storage~CommitResult} callback.commitResult - status of the commit made
      * @return {external:Promise} If no callback is given, the result will be provided in a promise
      */
     PluginBase.prototype.save = function (message, callback) {

--- a/src/server/storage/safestorage.js
+++ b/src/server/storage/safestorage.js
@@ -656,9 +656,8 @@ SafeStorage.prototype.getHistory = function (data, callback) {
     rejected = check(data !== null && typeof data === 'object', deferred, 'data is not an object.') ||
         check(typeof data.projectId === 'string', deferred, 'data.projectId is not a string.') ||
         check(REGEXP.PROJECT.test(data.projectId), deferred, 'data.projectId failed regexp: ' + data.projectId) ||
-        check(typeof data.start === 'string' ||
-            (typeof data.start === 'object' && data.start instanceof Array),
-        deferred, 'data.start is not a string or array') ||
+        check(typeof data.start === 'string' || (typeof data.start === 'object' && data.start instanceof Array),
+            deferred, 'data.start is not a string or array') ||
         check(typeof data.number === 'number', deferred, 'data.number is not a number');
 
     if (data.hasOwnProperty('username')) {
@@ -789,9 +788,11 @@ SafeStorage.prototype.makeCommit = function (data, callback) {
                 'data.commitObject._id is not a valid hash: ' + data.commitObject._id) ||
             check(data.commitObject.parents instanceof Array, deferred,
                 'data.commitObject.parents is not an array.') ||
-            check(typeof data.commitObject.parents[0] === 'string', deferred,
+            check(data.commitObject.parents.length === 0 || typeof data.commitObject.parents[0] === 'string', deferred,
                 'data.commitObject.parents[0] is not a string.') ||
-            check(data.commitObject.parents[0] === '' || REGEXP.HASH.test(data.commitObject.parents[0]), deferred,
+            check(
+                data.commitObject.parents.length === 0 || data.commitObject.parents[0] === '' ||
+                REGEXP.HASH.test(data.commitObject.parents[0]), deferred,
                 'data.commitObject.parents[0] is not a valid hash: ' + data.commitObject.parents[0]) ||
             check(REGEXP.HASH.test(data.commitObject.root), deferred,
                 'data.commitObject.root is not a valid hash: ' + data.commitObject.root);


### PR DESCRIPTION
This PR also fixes:
- Client correctly emits when it can undo/redo.
- Undo/Redo now also resolves with the commit-result.