### PR TITLE
Fixes #144 By parsing WEBGME_* environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# WebGME-Engine
-This is the "engine" of the webgme app containing all server code, common-modules and client-api.
+[![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://opensource.org/licenses/MIT)
+[![Build Status](https://travis-ci.org/webgme/webgme-engine.svg?branch=master)](https://travis-ci.org/webgme/webgme-engine)
+[![Version](https://badge.fury.io/js/webgme-engine.svg)](https://www.npmjs.com/package/webgme-engine)
+[![Downloads](http://img.shields.io/npm/dm/webgme-engine.svg?style=flat)](http://img.shields.io/npm/dm/webgme-engine.svg?style=flat)
+
+# webgme-engine
+This is the "engine" of the [webgme application](https://github.com/webgme/webgme/) and contains all server code, common-modules and client-api.
 If this is your first encounter with webgme the [webgme/webgme](https://github.com/webgme/webgme/) is probably what you're looking for.
 
 The webgme-engine was forked off from webgme/webgme at [version v2.17.0](https://github.com/webgme/webgme/releases/tag/v2.17.0) and since then is released separately from webgme starting off from v2.18.0.
@@ -33,7 +38,7 @@ Each script supports the `--help` or `-h` command line parameter, which will lis
 * `manage_webhooks.js`: add/update/remove webhooks to and from projects.
 * `blob_fs_clean_up.js`: cleans up blobs from the filesystem that are not referenced from any projects.
 * `plugin_hook.js`: plugin developer utility for triggering plugin on changes made to a project.
-* `storage_stats.js`: outputs statistics about the projects in the database. 
+* `storage_stats.js`: outputs statistics about the projects in the database.
 * `connected_webhook_handler.js`: webhook example illustrating how to create an authenticated remote connection to the storage (models).
 
 

--- a/config/index.js
+++ b/config/index.js
@@ -8,10 +8,12 @@
 var env = process.env.NODE_ENV || 'default',
     configFilename = __dirname + '/config.' + env + '.js',
     config = require(configFilename),
-    validateConfig = require(__dirname + '/validator').validateConfig;
+    validateConfig = require(__dirname + '/validator').validateConfig,
+    overrideFromEnv = require('./overridefromenv');
 
 console.info('Using configuration from ' + configFilename);
-validateConfig(configFilename);
+overrideFromEnv(config);
+validateConfig(config);
 
 module.exports = config;
 

--- a/config/overridefromenv.js
+++ b/config/overridefromenv.js
@@ -5,6 +5,8 @@
  * Updates the passed in gmeConfig with values from environment variables starting with GME_.
  * See https://github.com/webgme/webgme-engine/issues/144 for details
  *
+ * This needs to be included and called inside the config/index.js of the repository using webgme(engine).
+ *
  * @author pmeijer / https://github.com/pmeijer
  *
  */
@@ -14,8 +16,7 @@
  * @param {object} config
  */
 function overrideFromEnv(config) {
-    var env = process.env,
-        hadEnv = false;
+    var env = process.env;
 
     Object.keys(env)
         .forEach(function (key) {

--- a/config/overridefromenv.js
+++ b/config/overridefromenv.js
@@ -1,0 +1,65 @@
+/*eslint-env node*/
+/*eslint no-console: 0*/
+
+/**
+ * Updates the passed in gmeConfig with values from environment variables starting with GME_.
+ * See https://github.com/webgme/webgme-engine/issues/144 for details
+ * Note that the passed in config is mutated!
+ * @param {object} config
+ */
+function overrideFromEnv(config) {
+    var env = process.env;
+
+    Object.keys(env)
+        .forEach(function (key) {
+            if (key.indexOf('GME_') === 0) {
+                var configPath,
+                    subConfig,
+                    wasCreated,
+                    value;
+
+                try {
+                    value = JSON.parse(env[key]);
+                } catch (e) {
+                    if (e instanceof SyntaxError) {
+                        // Regular string value
+                        value = env[key];
+                    } else {
+                        throw e;
+                    }
+                }
+
+                configPath = key.split('_').slice(1);
+
+                subConfig = config;
+                configPath.forEach(function (cfgName, idx) {
+                    wasCreated = wasCreated || (subConfig.hasOwnProperty(cfgName) === false);
+                    if (idx === configPath.length - 1) {
+                        subConfig[cfgName] = value;
+                        console.log('ENV ' + (wasCreated ? 'created' : 'updated') +
+                            ' config.' + configPath.join('.') + '=' + value + ' <' + typeof value + '>');
+                    } else {
+                        if (subConfig.hasOwnProperty(cfgName) === false) {
+                            subConfig[cfgName] = {};
+                        } else if (typeof subConfig[cfgName] !== 'object' ||
+                            subConfig[cfgName] === null ||
+                            subConfig instanceof Array) {
+                            throw new Error(key + ' would override non-object config path at ' + [cfgName]);
+                        }
+
+                        subConfig  = subConfig[cfgName];
+                    }
+                });
+            }
+        });
+}
+
+// var myConfig = {
+//     authentication: {
+//         allowGuests: true,
+//     }
+// };
+// overrideFromEnv(myConfig);
+// console.log(myConfig);
+
+module.exports = overrideFromEnv;

--- a/config/overridefromenv.js
+++ b/config/overridefromenv.js
@@ -4,20 +4,28 @@
 /**
  * Updates the passed in gmeConfig with values from environment variables starting with GME_.
  * See https://github.com/webgme/webgme-engine/issues/144 for details
+ *
+ * @author pmeijer / https://github.com/pmeijer
+ *
+ */
+
+/**
  * Note that the passed in config is mutated!
  * @param {object} config
  */
 function overrideFromEnv(config) {
-    var env = process.env;
+    var env = process.env,
+        hadEnv = false;
 
     Object.keys(env)
         .forEach(function (key) {
-            if (key.indexOf('GME_') === 0) {
+            if (key.indexOf('WEBGME_') === 0) {
                 var configPath,
                     subConfig,
                     wasCreated,
                     value;
 
+                hadEnv = true;
                 try {
                     value = JSON.parse(env[key]);
                 } catch (e) {
@@ -43,8 +51,9 @@ function overrideFromEnv(config) {
                             subConfig[cfgName] = {};
                         } else if (typeof subConfig[cfgName] !== 'object' ||
                             subConfig[cfgName] === null ||
-                            subConfig instanceof Array) {
-                            throw new Error(key + ' would override non-object config path at ' + [cfgName]);
+                            subConfig[cfgName] instanceof Array) {
+                            throw new Error(key + ' would override non-object config at "config.' +
+                                configPath.slice(0, idx + 1).join('.') + '".');
                         }
 
                         subConfig  = subConfig[cfgName];
@@ -53,13 +62,5 @@ function overrideFromEnv(config) {
             }
         });
 }
-
-// var myConfig = {
-//     authentication: {
-//         allowGuests: true,
-//     }
-// };
-// overrideFromEnv(myConfig);
-// console.log(myConfig);
 
 module.exports = overrideFromEnv;

--- a/config/overridefromenv.js
+++ b/config/overridefromenv.js
@@ -26,7 +26,6 @@ function overrideFromEnv(config) {
                     wasCreated,
                     value;
 
-                hadEnv = true;
                 try {
                     value = JSON.parse(env[key]);
                 } catch (e) {

--- a/test/config/config.spec.js
+++ b/test/config/config.spec.js
@@ -331,12 +331,11 @@ describe('configuration and components', function () {
         process.env.NODE_ENV = 'default';
         unloadConfigs();
         process.env['WEBGME_addOn_basePaths_12'] = './attempt/to/mess/up/array';
-        process.env['WEBGME_addOn_basePaths_10'] = './attempt/to/mess/up/array2';
         try {
             require('../../config');
             throw new Error('Should have failed!');
         } catch (e) {
-            if (e.message.indexOf('WEBGME_addOn_basePaths_10 would override non-object config at') === -1) {
+            if (e.message.indexOf('WEBGME_addOn_basePaths_12 would override non-object config at') === -1) {
                 throw e;
             }
         }

--- a/test/config/config.spec.js
+++ b/test/config/config.spec.js
@@ -42,6 +42,14 @@ describe('configuration and components', function () {
         unloadConfigs();
     });
 
+    afterEach(function () {
+        Object.keys(process.env).forEach(function (key) {
+            if (key.indexOf('WEBGME_') === 0) {
+                delete process.env[key];
+            }
+        });
+    });
+
     after(function () {
         process.chdir(oldCwd);
         unloadConfigs();
@@ -268,5 +276,92 @@ describe('configuration and components', function () {
                 expect(json).to.deep.equal({});
             })
             .nodeify(done);
+    });
+
+    // Using WEBGME_* environment variables.
+
+    it('should change server port and it should be an integer when passed via WEBGME_env', function () {
+        process.env.NODE_ENV = 'default';
+        var configOrg = require('../../config');
+        unloadConfigs();
+        process.env['WEBGME_server_port'] = '8008';
+        var configEnv = require('../../config');
+
+        expect(configEnv.server.port).to.not.equal(configOrg.server.port);
+        expect(configEnv.server.port).to.equal(8008);
+    });
+
+    it('should change authentication enable and it should be a boolean when passed via WEBGME_env', function () {
+        process.env.NODE_ENV = 'default';
+        var configOrg = require('../../config');
+        unloadConfigs();
+        process.env['WEBGME_authentication_enable'] = 'true';
+        var configEnv = require('../../config');
+
+        expect(configEnv.authentication.enable).to.not.equal(configOrg.authentication.enable);
+        expect(configEnv.authentication.enable).to.equal(true);
+    });
+
+    it('should change defaultSeed and it should be a string when passed via WEBGME_env', function () {
+        process.env.NODE_ENV = 'default';
+        var configOrg = require('../../config');
+        unloadConfigs();
+        process.env['WEBGME_seedProjects_defaultProject'] = 'MyLittleSeed';
+        var configEnv = require('../../config');
+
+        expect(configEnv.seedProjects.defaultProject).to.not.equal(configOrg.seedProjects.defaultProject);
+        expect(configEnv.seedProjects.defaultProject).to.equal('MyLittleSeed');
+    });
+
+    it('should throw if encountering non-object (bool) in config path passed via WEBGME_env', function () {
+        process.env.NODE_ENV = 'default';
+        unloadConfigs();
+        process.env['WEBGME_authentication_enable_doIt'] = 'true';
+        try {
+            require('../../config');
+            throw new Error('Should have failed!');
+        } catch (e) {
+            if (e.message.indexOf('WEBGME_authentication_enable_doIt would override non-object config at') === -1) {
+                throw e;
+            }
+        }
+    });
+
+    it('should throw if encountering non-object (array) in config path passed via WEBGME_env', function () {
+        process.env.NODE_ENV = 'default';
+        unloadConfigs();
+        process.env['WEBGME_addOn_basePaths_12'] = './attempt/to/mess/up/array';
+        process.env['WEBGME_addOn_basePaths_10'] = './attempt/to/mess/up/array2';
+        try {
+            require('../../config');
+            throw new Error('Should have failed!');
+        } catch (e) {
+            if (e.message.indexOf('WEBGME_addOn_basePaths_10 would override non-object config at') === -1) {
+                throw e;
+            }
+        }
+    });
+
+    it('should create sub-configs when passed via WEBGME_env and not colliding with non object.', function () {
+        process.env.NODE_ENV = 'default';
+        var configOrg = require('../../config');
+        unloadConfigs();
+        process.env['WEBGME_rest_components_myRouter_mount'] = 'myRoute';
+        process.env['WEBGME_rest_components_myRouter_src'] = 'my-route-module';
+        process.env['WEBGME_rest_components_myRouter_options_subOptions_someCfg1'] = true;
+        process.env['WEBGME_rest_components_myRouter_options_subOptions_someCfg2'] = true;
+        var configEnv = require('../../config');
+
+        expect(typeof configOrg.rest.components.myRouter).to.equal('undefined');
+        expect(configEnv.rest.components.myRouter).to.deep.equal({
+            mount: 'myRoute',
+            src: 'my-route-module',
+            options: {
+                subOptions: {
+                    someCfg1: true,
+                    someCfg2: true,
+                }
+            }
+        });
     });
 });


### PR DESCRIPTION
See #144 for details.

Note that for this to take place the function must be imported and called in `config/index.js`.
[webgme](https://github.com/webgme/webgme) will be updated to include a proxy so end-repos can require it via `require('webgme/config/overridefromenv')`..