### PR TITLE
Fixes #151 and returns actual ancestor for core.getCommonParent/Base

### DIFF
--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -395,10 +395,11 @@ define([
         };
 
         /**
-         * Returns the common parent node of all supplied nodes.
+         * Returns the common parent node of all supplied nodes. If a node and its parent are passed, the method will
+         * return the parent of the parent.
          * @param {...module:Core~Node} nodes - a variable number of nodes to compare
          *
-         * @return {module:Core~Node|null} The common base or null if no nodes were passed.
+         * @return {module:Core~Node|null} The common parent. Will be null whenever the root-node is passed in.
          * @example
          * core.getCommonParent(node1, node2, node3);
          * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
@@ -417,6 +418,10 @@ define([
 
             for (i = 1; i < nodesArr.length; i += 1) {
                 result = getCommonAncestor(result, nodesArr[i], core.getParent);
+            }
+
+            if (result && nodesArr.indexOf(result) > -1) {
+                result = core.getParent(result);
             }
 
             return result || null;
@@ -1298,7 +1303,7 @@ define([
          * Returns the common base node of all supplied nodes.
          * @param {...module:Core~Node} nodes - a variable number of nodes to compare
          *
-         * @return {module:Core~Node|null} The common base or null if e.g. the root node was passed.
+         * @return {module:Core~Node|null} The common base or null if e.g. the root node was passed or the fco.
          * @example
          * core.getCommonBase(node1, node2, node3);
          * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
@@ -1317,6 +1322,10 @@ define([
 
             for (i = 1; i < nodesArr.length; i += 1) {
                 result = getCommonAncestor(result, nodesArr[i], core.getBase);
+            }
+
+            if (result && nodesArr.indexOf(result) > -1) {
+                result = core.getBase(result);
             }
 
             return result || null;

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -395,8 +395,8 @@ define([
         };
 
         /**
-         * Returns the common parent node of all supplied nodes. If a node and its parent are passed, the method will
-         * return the parent of the parent.
+         * Returns the common parent node of all supplied nodes. Note that if a node and its parent are passed,
+         * the method will return the parent of the parent.
          * @param {...module:Core~Node} nodes - a variable number of nodes to compare
          *
          * @return {module:Core~Node|null} The common parent. Will be null whenever the root-node is passed in.
@@ -1300,7 +1300,8 @@ define([
         };
 
         /**
-         * Returns the common base node of all supplied nodes.
+         * Returns the common base node of all supplied nodes. Note that if a node and its base are passed,
+         * the method will return the base of the base.
          * @param {...module:Core~Node} nodes - a variable number of nodes to compare
          *
          * @return {module:Core~Node|null} The common base or null if e.g. the root node was passed or the fco.

--- a/test/client/js/client/gmeNodeGetter.spec.js
+++ b/test/client/js/client/gmeNodeGetter.spec.js
@@ -874,7 +874,18 @@ describe('gmeNodeGetter', function () {
         getNode('/1303043463/2119137141', logger, basicState, basicStoreNode);
         getNode('', logger, basicState, basicStoreNode);
 
-        expect(node.getCommonParentId('/175547009/1817665259', '/1303043463/2119137141', '')).to.eql('');
+        expect(node.getCommonParentId('/175547009/1817665259', '/1303043463/2119137141')).to.eql('');
+    });
+
+    it('should return null if root path is passed to getCommonParentId', function () {
+        var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode);
+
+        // Ensure the node are loaded
+        getNode('/175547009/1817665259', logger, basicState, basicStoreNode);
+        getNode('/1303043463/2119137141', logger, basicState, basicStoreNode);
+        getNode('', logger, basicState, basicStoreNode);
+
+        expect(node.getCommonParentId('/175547009/1817665259', '/1303043463/2119137141', '')).to.eql(null);
     });
 
     it('should throw at getCommonParentId if compare node not loaded/does not exist', function () {

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -5107,22 +5107,21 @@ describe('core', function () {
         expect(core.getCommonBase()).to.equal(null);
     });
 
-    it('getCommonBase should return same node if only one provided', function () {
-        expect(core.getCommonBase(ir.rootNode)).to.equal(ir.rootNode);
-        expect(core.getCommonBase(ir.FCO)).to.equal(ir.FCO);
+    it('getCommonBase should return null for both ROOT and FCO node if only one provided', function () {
+        expect(core.getCommonBase(ir.rootNode)).to.equal(null);
+        expect(core.getCommonBase(ir.FCO)).to.equal(null);
     });
 
-    it('getCommonParent should return same node if only one provided', function () {
-        expect(core.getCommonParent(ir.rootNode)).to.equal(ir.rootNode);
-        expect(core.getCommonParent(ir.FCO)).to.equal(ir.FCO);
+    it('getCommonParent should return parent only one provided', function () {
+        expect(core.getCommonParent(ir.FCO)).to.equal(ir.rootNode);
     });
 
     it('getCommonBase should return null if ROOT provided', function () {
         expect(core.getCommonBase(ir.rootNode, ir.FCO)).to.equal(null);
     });
 
-    it('getCommonParent should return ROOT if ROOT provided', function () {
-        expect(core.getCommonParent(ir.rootNode, ir.FCO)).to.equal(ir.rootNode);
+    it('getCommonParent should return null if ROOT provided', function () {
+        expect(core.getCommonParent(ir.rootNode, ir.FCO)).to.equal(null);
     });
 
     it('getCommonBase for more than two nodes', function (done) {
@@ -5132,17 +5131,20 @@ describe('core', function () {
 
                 var child1 = core.createNode({base: fco, parent: rootNode});
                 var child2 = core.createNode({base: child1, parent: rootNode});
+                var child21 = core.createNode({base: child1, parent: rootNode});
                 var child3 = core.createNode({base: fco, parent: rootNode});
                 var child4 = core.createNode({base: child3, parent: rootNode});
 
 
-                expect(core.getCommonBase(child1, child2, fco)).to.equal(fco);
-                expect(core.getCommonBase(fco, child1, child2)).to.equal(fco);
-                expect(core.getCommonBase(child2, fco, child1)).to.equal(fco);
+                expect(core.getCommonBase(child1, child2, fco)).to.equal(null);
+
+                expect(core.getCommonBase(fco, child1, child2)).to.equal(null);
+                expect(core.getCommonBase(child2, fco, child1)).to.equal(null);
 
                 expect(core.getCommonBase(child4, child2)).to.equal(fco);
 
-                expect(core.getCommonBase(child4, child3)).to.equal(child3);
+                expect(core.getCommonBase(child21, child2)).to.equal(child1);
+                expect(core.getCommonBase(child4, child3)).to.equal(fco);
 
                 expect(core.getCommonBase(child2, fco, child1, rootNode)).to.equal(null);
             })
@@ -5155,22 +5157,29 @@ describe('core', function () {
                 var fco = core.getFCO(rootNode);
 
                 var child1 = core.createNode({base: fco, parent: rootNode});
-                var child2 = core.createNode({base: fco, parent: child1});
-                var child3 = core.createNode({base: fco, parent: child2});
+                var child12 = core.createNode({base: fco, parent: child1});
+                var child121 = core.createNode({base: fco, parent: child12});
+                var child122 = core.createNode({base: fco, parent: child12});
+                var child1221 = core.createNode({base: fco, parent: child122});
+                var child1222 = core.createNode({base: fco, parent: child122});
 
-                var child4 = core.createNode({base: fco, parent: rootNode});
-                var child5 = core.createNode({base: fco, parent: child4});
+                var child2 = core.createNode({base: fco, parent: rootNode});
+                var child21 = core.createNode({base: fco, parent: child2});
 
 
-                expect(core.getCommonParent(child1, child2, fco)).to.equal(rootNode);
-                expect(core.getCommonParent(fco, child1, child2)).to.equal(rootNode);
-                expect(core.getCommonParent(child2, fco, child1)).to.equal(rootNode);
+                expect(core.getCommonParent(child1, child12, fco)).to.equal(rootNode);
+                expect(core.getCommonParent(fco, child1, child12)).to.equal(rootNode);
+                expect(core.getCommonParent(child12, fco, child1)).to.equal(rootNode);
 
-                expect(core.getCommonParent(child2, child3)).to.equal(child2);
+                expect(core.getCommonParent(child122, child121, child1221)).to.equal(child12);
+                expect(core.getCommonParent(child122, child121, child1221)).to.equal(child12);
+                expect(core.getCommonParent(child122, child122)).to.equal(child12);
 
-                expect(core.getCommonParent(child4, child5)).to.equal(child4);
+                expect(core.getCommonParent(child1222, child1221)).to.equal(child122);
 
-                expect(core.getCommonParent(child3, child5)).to.equal(rootNode);
+                expect(core.getCommonParent(child2, child21)).to.equal(rootNode);
+
+                expect(core.getCommonParent(child121, child21)).to.equal(rootNode);
             })
             .nodeify(done);
     });


### PR DESCRIPTION
See #151 for details and reasoning why it was implemented wrongly before.