### PR TITLE
Add isValidSetMember method to core API.

### DIFF
--- a/src/client/gmeNodeGetter.js
+++ b/src/client/gmeNodeGetter.js
@@ -538,6 +538,16 @@ define([], function () {
         }
     };
 
+    GMENode.prototype.isValidMemberOf = function (setOwnerPath, name) {
+        var setOwner = _getNode(this._state.nodes, setOwnerPath);
+
+        if (setOwner) {
+            return this._state.core.isValidMemberOf(this._state.nodes[this._id].node, setOwner, name);
+        } else {
+            return false;
+        }
+    };
+
     GMENode.prototype.getValidAspectNames = function () {
         return this._state.core.getValidAspectNames(this._state.nodes[this._id].node);
     };

--- a/src/client/gmeNodeGetter.js
+++ b/src/client/gmeNodeGetter.js
@@ -538,11 +538,11 @@ define([], function () {
         }
     };
 
-    GMENode.prototype.isValidMemberOf = function (setOwnerPath, name) {
+    GMENode.prototype.isValidSetMemberOf = function (setOwnerPath, name) {
         var setOwner = _getNode(this._state.nodes, setOwnerPath);
 
         if (setOwner) {
-            return this._state.core.isValidMemberOf(this._state.nodes[this._id].node, setOwner, name);
+            return this._state.core.isValidSetMemberOf(this._state.nodes[this._id].node, setOwner, name);
         } else {
             return false;
         }

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -2574,6 +2574,28 @@ define([
         };
 
         /**
+         * Checks if the node can be a member of the given set at the provided set-owner node. This does not take
+         * cardinality rules into account.
+         * @param {module:Core~Node} node - the node in question.
+         * @param {module:Core~Node} setOwner - the owner of the set.
+         * @param {string} name - the name of the set.
+         *
+         * @return {bool} The function returns true if according to the META rules, the given node is a valid
+         * member of set of the given set-owner.
+         *
+         * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
+         * @throws {CoreInternalError} If some internal error took place inside the core layers.
+         */
+        this.isValidMemberOf = function (node, setOwner, name) {
+            ensureNode(node, 'node');
+            ensureNode(setOwner, 'setOwner');
+            ensureType(name, 'name', 'string');
+
+            // This is not a typo - the isValidTargetOf method can be reused.
+            return core.isValidTargetOf(node, setOwner, name);
+        };
+
+        /**
          * Returns the list of the META defined attribute names of the node.
          * @param {module:Core~Node} node - the node in question.
          *

--- a/src/common/core/core.js
+++ b/src/common/core/core.js
@@ -2586,7 +2586,7 @@ define([
          * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
          * @throws {CoreInternalError} If some internal error took place inside the core layers.
          */
-        this.isValidMemberOf = function (node, setOwner, name) {
+        this.isValidSetMemberOf = function (node, setOwner, name) {
             ensureNode(node, 'node');
             ensureNode(setOwner, 'setOwner');
             ensureType(name, 'name', 'string');

--- a/test/client/js/client/gmeNodeGetter.spec.js
+++ b/test/client/js/client/gmeNodeGetter.spec.js
@@ -816,8 +816,8 @@ describe('gmeNodeGetter', function () {
     it('should check if the node is a valid member of the given set', function () {
         var node = getNode('/1303043463/1044885565', logger, basicState, basicStoreNode);
 
-        expect(node.isValidMemberOf('/1303043463/2119137141', 'setPtr')).to.eql(true);
-        expect(node.isValidMemberOf('/1303043463', 'setPtr')).to.eql(false);
+        expect(node.isValidSetMemberOf('/1303043463/2119137141', 'setPtr')).to.eql(true);
+        expect(node.isValidSetMemberOf('/1303043463', 'setPtr')).to.eql(false);
     });
 
 

--- a/test/client/js/client/gmeNodeGetter.spec.js
+++ b/test/client/js/client/gmeNodeGetter.spec.js
@@ -813,6 +813,13 @@ describe('gmeNodeGetter', function () {
         expect(node.isValidTargetOf('/1303043463/1448030591', 'setPtr')).to.eql(false);
     });
 
+    it('should check if the node is a valid member of the given set', function () {
+        var node = getNode('/1303043463/1044885565', logger, basicState, basicStoreNode);
+
+        expect(node.isValidMemberOf('/1303043463/2119137141', 'setPtr')).to.eql(true);
+        expect(node.isValidMemberOf('/1303043463', 'setPtr')).to.eql(false);
+    });
+
 
     it('should return the common base', function () {
         var node = getNode('/175547009/871430202', logger, basicState, basicStoreNode);

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -103,7 +103,7 @@ describe('core', function () {
                 'setMemberRegistry', 'delMemberRegistry', 'isMemberOf', 'getGuid',
                 'setGuid', 'getConstraint', 'setConstraint', 'delConstraint', 'getConstraintNames',
                 'getOwnConstraintNames', 'isTypeOf', 'isValidChildOf', 'getValidPointerNames',
-                'getValidSetNames', 'isValidTargetOf', 'isValidMemberOf', 'getValidAttributeNames',
+                'getValidSetNames', 'isValidTargetOf', 'isValidSetMemberOf', 'getValidAttributeNames',
                 'getOwnValidAttributeNames', 'isValidAttributeValueOf', 'getValidAspectNames',
                 'getOwnValidAspectNames', 'getAspectMeta', 'getJsonMeta', 'getOwnJsonMeta',
                 'clearMetaRules', 'setAttributeMeta', 'delAttributeMeta', 'getAttributeMeta',
@@ -2841,11 +2841,11 @@ describe('core', function () {
         }
     });
 
-    it('should throw @isValidMemberOf if not valid parameters are given', function () {
+    it('should throw @isValidSetMemberOf if not valid parameters are given', function () {
         var myError;
 
         try {
-            core.isValidMemberOf('string');
+            core.isValidSetMemberOf('string');
         } catch (e) {
             myError = e;
         } finally {
@@ -2854,7 +2854,7 @@ describe('core', function () {
         }
 
         try {
-            core.isValidMemberOf(rootNode, 'notnode');
+            core.isValidSetMemberOf(rootNode, 'notnode');
         } catch (e) {
             myError = e;
         } finally {
@@ -2863,7 +2863,7 @@ describe('core', function () {
         }
 
         try {
-            core.isValidMemberOf(rootNode, rootNode, {});
+            core.isValidSetMemberOf(rootNode, rootNode, {});
         } catch (e) {
             myError = e;
         } finally {

--- a/test/common/core/core.spec.js
+++ b/test/common/core/core.spec.js
@@ -103,7 +103,7 @@ describe('core', function () {
                 'setMemberRegistry', 'delMemberRegistry', 'isMemberOf', 'getGuid',
                 'setGuid', 'getConstraint', 'setConstraint', 'delConstraint', 'getConstraintNames',
                 'getOwnConstraintNames', 'isTypeOf', 'isValidChildOf', 'getValidPointerNames',
-                'getValidSetNames', 'isValidTargetOf', 'getValidAttributeNames',
+                'getValidSetNames', 'isValidTargetOf', 'isValidMemberOf', 'getValidAttributeNames',
                 'getOwnValidAttributeNames', 'isValidAttributeValueOf', 'getValidAspectNames',
                 'getOwnValidAspectNames', 'getAspectMeta', 'getJsonMeta', 'getOwnJsonMeta',
                 'clearMetaRules', 'setAttributeMeta', 'delAttributeMeta', 'getAttributeMeta',
@@ -2833,6 +2833,37 @@ describe('core', function () {
 
         try {
             core.isValidTargetOf(rootNode, rootNode, {});
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+    });
+
+    it('should throw @isValidMemberOf if not valid parameters are given', function () {
+        var myError;
+
+        try {
+            core.isValidMemberOf('string');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+
+        try {
+            core.isValidMemberOf(rootNode, 'notnode');
+        } catch (e) {
+            myError = e;
+        } finally {
+            expect(myError.name).to.eql('CoreIllegalArgumentError');
+            myError = null;
+        }
+
+        try {
+            core.isValidMemberOf(rootNode, rootNode, {});
         } catch (e) {
             myError = e;
         } finally {


### PR DESCRIPTION
```
        /**
         * Checks if the node can be a member of the given set at the provided set-owner node. This does not take
         * cardinality rules into account.
         * @param {module:Core~Node} node - the node in question.
         * @param {module:Core~Node} setOwner - the owner of the set.
         * @param {string} name - the name of the set.
         *
         * @return {bool} The function returns true if according to the META rules, the given node is a valid
         * member of set of the given set-owner.
         *
         * @throws {CoreIllegalArgumentError} If some of the parameters don't match the input criteria.
         * @throws {CoreInternalError} If some internal error took place inside the core layers.
         */
        core.isValidSetMemberOf = function (node, setOwner, name) {...}
```
The same method is added to GMENode on the client.