### PR TITLE
Update nodejs version of travis and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
 #   depth: 5
 
 node_js:
-  - "6"
   - "8"
   - "10"
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ one of these libraries.
 ## Developers
 
 ### Dependencies
- - [NodeJS](https://nodejs.org/) (version >= 4, CI tests are performed on versions 6.x, 8.x and LTS is recommended).
+ - [NodeJS](https://nodejs.org/) (version >= 4, CI tests are performed on versions 8.x, 10.x and LTS is recommended).
  - [MongoDB](https://www.mongodb.com/) (version >= 2.6).
  - [Git](https://git-scm.com) (must be available in PATH).
  - [Redis](https://redis.io/) needed to run all tests and if serving under multiple nodes.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 
 environment:
   matrix:
-  - nodejs_version: "8"
+  - nodejs_version: "10"
     platform: x64
   # - nodejs_version: "4.2"
   #   platform: x86


### PR DESCRIPTION
https://nodejs.org/en/about/releases/

Appveyor: use active LTS

Travis: use active LTS + maintenance LTS (+ Current to-be LTS)

