### PR TITLE
Handle old string errors and make sure result.error isn't overwritten

### DIFF
--- a/src/plugin/PluginResult.js
+++ b/src/plugin/PluginResult.js
@@ -159,6 +159,11 @@
      * @param {string} time
      */
     PluginResult.prototype.setError = function (error) {
+        if (this.error) {
+            // Do not overwrite user defined error.
+            return;
+        }
+
         if (error instanceof Error) {
             this.error = error.message;
         } else {

--- a/src/plugin/managerbase.js
+++ b/src/plugin/managerbase.js
@@ -315,7 +315,7 @@ define([
                 } else {
                     result.setError(err);
                     plugin.notificationHandlers = [];
-                    callback(err, result);
+                    callback(typeof err === 'string' ? new Error(err) : err, result);
                 }
             });
         };

--- a/test/plugin/coreplugins/MetaGMEParadigmImporter/MetaGMEParadigmImporter.spec.js
+++ b/test/plugin/coreplugins/MetaGMEParadigmImporter/MetaGMEParadigmImporter.spec.js
@@ -206,7 +206,7 @@ describe('Plugin MetaGMEParadigmImporter', function () {
             };
 
         pluginManager.executePlugin(pluginName, pluginConfig, pluginContext, function (err, result) {
-            expect(err).to.include('Error: Invalid xmpData: paradigm key does not exist.');
+            expect(err.message).to.include('Error: Invalid xmpData: paradigm key does not exist.');
             expect(result.success).to.equal(false);
             done();
         });


### PR DESCRIPTION
This ensures that errors returned as `string`s in the main callback are converted to `Error`s.

Additionally the result.error isn't overwritten by the framework- which allows the plugin itself to set an error message (together with a `result.success = false`) and not resolve with an error in main. That way the entire error stack won't show up in the failed result dialog. (This approach can be used when there's an expected error and a brief, more user friendly, message is appropriate.)