### PR TITLE
Add auth to executor framework (and access tokens). Closes #170

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,9 @@
   "env": {
     "es6": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
   "globals": {},
   "extends": "eslint:recommended",
   "rules": {

--- a/config/README.md
+++ b/config/README.md
@@ -149,6 +149,10 @@ Modification of arrays is not support, but non-existing config sub-group (object
 
 - `config.executor.enable = false`
  - If true will enable the executor.
+- `config.executor.authentication.enable = false`
+ - If true will enable authentication for the executors allowing them to be associated with a given user. Executors will only be able to view jobs from the given owner (or guest). Workers are associated with a user by providing a user's personal access token in the worker's config.
+- `config.executor.authentication.allowGuests = true`
+ - If true will require jobs and workers to be associated with an existing user.
 - `config.executor.nonce = null`
  - If defined this is the secret shared between the server and attached workers.
 - `config.executor.workerRefreshInterval = 5000`

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -106,6 +106,10 @@ var path = require('path'),
 
         executor: {
             enable: false,
+            authentication: {
+                enable: false,
+                allowGuests: true,
+            },
             nonce: null,
             workerRefreshInterval: 5000,
             clearOutputTimeout: 60000,

--- a/config/validator.js
+++ b/config/validator.js
@@ -182,6 +182,8 @@ function validateConfig(configOrFileName) {
     expectedKeys.push('executor');
     assertObject('config.executor', config.executor);
     assertBoolean('config.executor.enable', config.executor.enable);
+    assertBoolean('config.executor.authentication.enable', config.executor.authentication.enable);
+    assertBoolean('config.executor.authentication.allowGuests', config.executor.authentication.allowGuests);
     assertString('config.executor.nonce', config.executor.nonce, true);
     warnDeprecated('config.executor.outputDir', config.executor.outputDir);
     assertString('config.executor.labelJobs', config.executor.labelJobs);

--- a/src/common/executor/ExecutorClient.js
+++ b/src/common/executor/ExecutorClient.js
@@ -75,11 +75,8 @@ define(['superagent', 'q'], function (superagent, Q) {
         }
         this.executorUrl = this.origin + this.relativeUrl;
 
-        // TODO: TOKEN???
-        // TODO: any ways to ask for this or get it from the configuration?
-        if (parameters.executorNonce) {
-            this.executorNonce = parameters.executorNonce;
-        }
+        this.executorNonce = parameters.executorNonce;
+        this.apiToken = parameters.apiToken;
 
         this.logger.debug('origin', this.origin);
         this.logger.debug('executorUrl', this.executorUrl);
@@ -375,6 +372,9 @@ define(['superagent', 'q'], function (superagent, Q) {
         var req = new superagent.Request(method, url);
         if (this.executorNonce) {
             req.set('x-executor-nonce', this.executorNonce);
+        }
+        if (this.apiToken) {
+            req.set('x-api-token', this.apiToken);
         }
         if (data) {
             req.send(data);

--- a/src/common/executor/ExecutorClient.js
+++ b/src/common/executor/ExecutorClient.js
@@ -77,6 +77,7 @@ define(['superagent', 'q'], function (superagent, Q) {
 
         this.executorNonce = parameters.executorNonce;
         this.apiToken = parameters.apiToken;
+        this.webgmeToken = parameters.webgmeToken;
 
         this.logger.debug('origin', this.origin);
         this.logger.debug('executorUrl', this.executorUrl);
@@ -375,6 +376,9 @@ define(['superagent', 'q'], function (superagent, Q) {
         }
         if (this.apiToken) {
             req.set('x-api-token', this.apiToken);
+        }
+        if (this.webgmeToken) {
+            req.set('Authorization', 'Bearer ' + this.webgmeToken);
         }
         if (data) {
             req.send(data);

--- a/src/server/middleware/access-tokens/TokenServer.js
+++ b/src/server/middleware/access-tokens/TokenServer.js
@@ -1,23 +1,14 @@
 /*eslint-env node*/
 
 /**
- * @author lattmann / https://github.com/lattmann
- * @author ksmyth / https://github.com/ksmyth
- * @author pmeijer / https://github.com/pmeijer
- *
- curl http://localhost:8855/rest/executor/info/77704f10a36aa4214f5b0095ba8099e729a10f46
- curl -X POST -H "Content-Type: application/json"
- -d {} http://localhost:8855/rest/executor/create/77704f10a36aa4214f5b0095ba8099e729a10f46
- curl -X POST -H "Content-Type: application/json"
- -d {\"status\":\"CREATED\"} http://localhost:8855/rest/executor/update/77704f10a36aa4214f5b0095ba8099e729a10f46
+ * @author brollb / https://github.com/brollb
  */
 
 'use strict';
 
-var express = require('express'),
-    Chance = require('chance'),
-    // Mongo collections
-    TOKEN_LIST = '_tokenList';
+const express = require('express');
+const Chance = require('chance');
+const TOKEN_COLLECTION = '_tokenList';
 
 /**
  *
@@ -61,7 +52,7 @@ function TokenServer(options) {
 TokenServer.prototype.start = async function (params) {
     this.logger.debug('Starting token server');
     const mongo = params.mongoClient;
-    const tokenList = await mongo.collection(TOKEN_LIST);
+    const tokenList = await mongo.collection(TOKEN_COLLECTION);
     this.tokens.init(tokenList);
 };
 

--- a/src/server/middleware/access-tokens/TokenServer.js
+++ b/src/server/middleware/access-tokens/TokenServer.js
@@ -1,0 +1,104 @@
+/*eslint-env node*/
+
+/**
+ * @author lattmann / https://github.com/lattmann
+ * @author ksmyth / https://github.com/ksmyth
+ * @author pmeijer / https://github.com/pmeijer
+ *
+ curl http://localhost:8855/rest/executor/info/77704f10a36aa4214f5b0095ba8099e729a10f46
+ curl -X POST -H "Content-Type: application/json"
+ -d {} http://localhost:8855/rest/executor/create/77704f10a36aa4214f5b0095ba8099e729a10f46
+ curl -X POST -H "Content-Type: application/json"
+ -d {\"status\":\"CREATED\"} http://localhost:8855/rest/executor/update/77704f10a36aa4214f5b0095ba8099e729a10f46
+ */
+
+'use strict';
+
+var express = require('express'),
+    Chance = require('chance'),
+    // Mongo collections
+    TOKEN_LIST = '_tokenList';
+
+/**
+ *
+ * @param {object} options - middlewareOptions
+ * @param {GmeLogger} options.logger - logger to fork off from
+ * @param {GmeConfig} options.gmeConfig - gmeConfig
+ * @param {function} options.ensureAuthenticated
+ * @constructor
+ * @ignore
+ */
+function TokenServer(options) {
+    var self = this,
+        router = express.Router();
+
+    self.logger = options.logger.fork('middleware:TokenServer');
+    self.ensureAuthenticated = options.ensureAuthenticated;
+    self.getUserId = options.getUserId;
+    self.router = router;
+    self.tokenList = null;
+
+    router.use('*', self.ensureAuthenticated);
+    router.get('/', async function (req, res) {
+        const userId = self.getUserId(req);
+        res.json(await self.tokens.list(userId));
+    });
+
+    router.post('/create', async function (req, res) {
+        const userId = self.getUserId(req);
+        const token = await self.tokens.create(userId);
+        res.json(token);
+    });
+
+    router.delete('/:id', async function (req, res) {
+        const userId = self.getUserId(req);
+        const deleted = await self.tokens.delete(userId, req.params.id);
+        res.json(deleted);
+    });
+
+}
+
+TokenServer.prototype.start = async function (params) {
+    this.logger.debug('Starting token server');
+    const mongo = params.mongoClient;
+    const tokenList = await mongo.collection(TOKEN_LIST);
+    this.tokens = new AccessTokens(tokenList);
+};
+
+function AccessTokens(tokenList) {
+    this.chance = new Chance();
+    this.tokenList = tokenList;
+    this.tokenList.createIndex({id: 1}, {unique: true});
+}
+
+AccessTokens.prototype.list = async function (userId) {
+    const tokens = await this.tokenList.find({userId}, {_id: 0}).toArray();
+    return tokens;
+};
+
+AccessTokens.prototype.create = async function (userId) {
+    const token = {
+        userId: userId,
+        id: this.chance.guid(),
+        issuedAt: new Date(),
+    };
+    await this.tokenList.save(token);
+    return token;
+};
+
+AccessTokens.prototype.delete = async function (userId, id) {
+    const result = await this.tokenList.deleteOne({userId, id});
+    return result.deletedCount;
+};
+
+AccessTokens.prototype.isValidToken = async function (userId, id) {
+    const token = await this.tokenList.findOne({userId, id});
+    return !!token;
+};
+
+AccessTokens.prototype.getUserId = async function (id) {
+    const token = await this.tokenList.findOne({id}, {_id: 0});
+    return token && token.userId;
+};
+
+module.exports = TokenServer;

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -89,7 +89,7 @@ function ExecutorServer(options) {
         }
     }
 
-    function workerTimeout() {
+    async function workerTimeout() {
         var query;
         if (process.uptime() < workerRefreshInterval / 1000 * 5) {
             return;
@@ -106,49 +106,42 @@ function ExecutorServer(options) {
             }
         }
 
-        self.workerList.find(query).toArray(function (err, docs) {
-            if (!self.running) {
-                self.logger.debug('ExecutorServer had been stopped.');
-                return;
-            }
-            for (var i = 0; i < docs.length; i += 1) {
-                // reset unfinished jobs assigned to worker to CREATED, so they'll be executed by someone else
-                self.logger.debug('worker "' + docs[i].clientId + '" is gone');
+        const docs = await self.workerList.find(query).toArray();
+        if (!self.running) {
+            self.logger.debug('ExecutorServer had been stopped.');
+            return;
+        }
+        for (var i = 0; i < docs.length; i += 1) {
+            // reset unfinished jobs assigned to worker to CREATED, so they'll be executed by someone else
+            self.logger.debug('worker "' + docs[i].clientId + '" is gone');
 
-                self.workerList.deleteOne({_id: docs[i]._id}, callback);
-                self.jobList.updateMany({worker: docs[i].clientId, status: {$nin: JobInfo.finishedStatuses}}, {
-                    $set: {
-                        worker: null,
-                        status: 'CREATED',
-                        startTime: null
-                    }
-                }, callback);
-            }
-        });
+            self.workerList.deleteOne({_id: docs[i]._id}, callback);
+            self.jobList.updateMany({worker: docs[i].clientId, status: {$nin: JobInfo.finishedStatuses}}, {
+                $set: {
+                    worker: null,
+                    status: 'CREATED',
+                    startTime: null
+                }
+            }, callback);
+        }
     }
 
-    function updateLabelJobs(callback) {
+    function updateLabelJobs() {
         fs.readFile(self.labelJobsFilename, {encoding: 'utf-8'}, function (err, data) {
             self.logger.debug('Reading ' + self.labelJobsFilename);
             self.labelJobs = JSON.parse(data);
-            if (callback) {
-                callback(err);
-            }
         });
     }
 
-    function watchLabelJobs(callback) {
+    function watchLabelJobs() {
         fs.exists(self.labelJobsFilename, function (exists) {
             if (exists) {
-                updateLabelJobs(callback);
+                updateLabelJobs();
                 fs.watch(self.labelJobsFilename, {persistent: false}, function () {
                     updateLabelsTimeoutId = setTimeout(updateLabelJobs, 200);
                 });
             } else {
                 watchLabelsTimeout = setTimeout(watchLabelJobs, 10 * 1000);
-                if (callback) {
-                    callback();
-                }
             }
         });
     }
@@ -251,32 +244,14 @@ function ExecutorServer(options) {
         return deferred.promise.nodeify(callback);
     }
 
-    function restartCanceledJob(oldJobInfo, newInfo, callback) {
-        function insertNewInfo() {
-            var deferred = Q.defer();
-
-            self.jobList.updateOne({hash: oldJobInfo.hash}, newInfo, {upsert: true}, function (err) {
-                if (err) {
-                    deferred.reject(err);
-                } else {
-                    deferred.resolve(newInfo);
-                }
-            });
-
-            return deferred.promise;
-        }
-
+    async function restartCanceledJob(oldJobInfo, newInfo) {
         if (self.clearOutputsTimers[oldJobInfo.hash] || oldJobInfo.outputNumber !== null) {
             delete self.clearOutputsTimers[oldJobInfo.hash];
 
-            return clearOutput(oldJobInfo)
-                .then(function () {
-                    return insertNewInfo();
-                })
-                .nodeify(callback);
-        } else {
-            return insertNewInfo().nodeify(callback);
+            await clearOutput(oldJobInfo);
         }
+        await self.jobList.updateOne({hash: oldJobInfo.hash}, newInfo, {upsert: true});
+        return newInfo;
 
     }
 
@@ -329,7 +304,7 @@ function ExecutorServer(options) {
         });
     });
 
-    router.post('/create/:hash', function (req, res/*, next*/) {
+    router.post('/create/:hash', async function (req, res/*, next*/) {
         var jobInfo,
             info = req.body;
 
@@ -341,11 +316,9 @@ function ExecutorServer(options) {
         jobInfo.secret = chance.guid();
 
         self.logger.debug('job creation info:', {metadata: info});
-        self.jobList.findOne({hash: req.params.hash}, function (err, doc) {
-            if (err) {
-                self.logger.error(err);
-                res.sendStatus(500);
-            } else if (!doc) {
+        try {
+            const doc = await self.jobList.findOne({hash: req.params.hash});
+            if (!doc) {
                 self.jobList.insertOne(jobInfo, function (err) {
                     if (err) {
                         // TODO: Deal with error when it already existed.
@@ -357,32 +330,26 @@ function ExecutorServer(options) {
                     }
                 });
             } else if (doc.status === 'CANCELED') {
-                restartCanceledJob(doc, jobInfo)
-                    .then(function (newInfo) {
-                        res.send(newInfo);
-                    })
-                    .catch(function (err) {
-                        self.logger.error(err);
-                        res.sendStatus(500);
-                    });
+                const newInfo = await restartCanceledJob(doc, jobInfo);
+                res.send(newInfo);
             } else {
                 delete doc._id;
                 delete doc.secret;
                 res.send(doc);
             }
-        });
+        } catch (err) {
+            self.logger.error(err);
+            res.sendStatus(500);
+        }
 
         // TODO: get job description
 
     });
 
-    router.post('/update/:hash', function (req, res/*, next*/) {
-
-        self.jobList.findOne({hash: req.params.hash}, function (err, doc) {
-            if (err) {
-                self.logger.error(err);
-                res.sendStatus(500);
-            } else if (doc) {
+    router.post('/update/:hash', async function (req, res/*, next*/) {
+        try {
+            const doc = await self.jobList.findOne({hash: req.params.hash});
+            if (doc) {
                 var jobInfo = new JobInfo(doc);
                 var jobInfoUpdate = new JobInfo(req.body);
                 jobInfoUpdate.hash = req.params.hash;
@@ -415,41 +382,37 @@ function ExecutorServer(options) {
             } else {
                 res.sendStatus(404);
             }
-        });
+        } catch (err) {
+            self.logger.error(err);
+            res.sendStatus(500);
+        }
     });
 
-    router.post('/cancel/:hash', function (req, res/*, next*/) {
-        self.jobList.findOne({hash: req.params.hash}, function (err, doc) {
-            if (err) {
-                self.logger.error(err);
-                res.sendStatus(500);
-            } else if (doc) {
+    router.post('/cancel/:hash', async function (req, res/*, next*/) {
+        try {
+            const doc = await self.jobList.findOne({hash: req.params.hash});
+            if (doc) {
                 if (req.body.secret !== doc.secret) {
-                    res.sendStatus(403);
+                    return res.sendStatus(403);
                 } else if (JobInfo.isFinishedStatus(doc.status) === false) {
                     // Only bother to update the cancelRequested if job hasn't finished.
-                    self.jobList.updateOne({hash: req.params.hash}, {
+                    await self.jobList.updateOne({hash: req.params.hash}, {
                         $set: {
                             cancelRequested: true
                         }
-                    }, function (err) {
-                        if (err) {
-                            self.logger.error(err);
-                            res.sendStatus(500);
-                        } else {
-                            res.sendStatus(200);
-                        }
                     });
-                } else {
-                    res.sendStatus(200);
                 }
+                res.sendStatus(200);
             } else {
                 res.sendStatus(404);
             }
-        });
+        } catch (err) {
+            self.logger.error(err);
+            res.sendStatus(500);
+        }
     });
 
-    router.get('/output/:hash', function (req, res/*, next*/) {
+    router.get('/output/:hash', async function (req, res/*, next*/) {
         var query = {
             hash: req.params.hash
         };
@@ -471,123 +434,94 @@ function ExecutorServer(options) {
         }
 
         self.logger.debug('ouput requested', query);
-        self.outputList.find(query)
-            .sort({outputNumber: 1})
-            .toArray(function (err, docs) {
-                if (err) {
-                    self.logger.error('get output', err);
-                    res.sendStatus(500);
-                    return;
-                }
+        try {
+            const docs = await self.outputList.find(query)
+                .sort({outputNumber: 1})
+                .toArray();
 
-                self.logger.debug('got outputs, nbr', docs.length);
-                if (docs.length > 0) {
+            self.logger.debug('got outputs, nbr', docs.length);
+            if (docs.length > 0) {
+                res.send(docs);
+            } else {
+                // No output found, could it be that job does not even exist?
+                const jobInfo = await self.jobList.findOne({hash: req.params.hash});
+                if (jobInfo) {
                     res.send(docs);
                 } else {
-                    // No output found, could it be that job does not even exist?
-                    self.jobList.findOne({hash: req.params.hash}, function (err, jobInfo) {
-                        if (err) {
-                            self.logger.error(err);
-                            res.sendStatus(500);
-                        } else if (jobInfo) {
-                            res.send(docs);
-                        } else {
-                            res.sendStatus(404);
-                        }
-                    });
+                    res.sendStatus(404);
                 }
-            });
+            }
+        } catch (err) {
+            self.logger.error('get output', err);
+            res.sendStatus(500);
+            return;
+        }
     });
 
-    router.post('/output/:hash', function (req, res/*, next*/) {
+    router.post('/output/:hash', async function (req, res/*, next*/) {
         var outputInfo = new OutputInfo(req.params.hash, req.body);
 
         self.logger.debug('output posted', outputInfo._id);
 
-        self.outputList.updateOne({_id: outputInfo._id}, outputInfo, {upsert: true}, function (err) {
-            if (err) {
-                self.logger.error('post output', err);
-                res.sendStatus(500);
-                return;
-            }
-
-            self.jobList.updateOne({hash: req.params.hash}, {
+        try {
+            await self.outputList.updateOne({_id: outputInfo._id}, outputInfo, {upsert: true});
+            const result = await self.jobList.updateOne({hash: req.params.hash}, {
                 $set: {
                     outputNumber: outputInfo.outputNumber
                 }
-            }, function (err, result) {
-                if (err) {
-                    self.logger.error('post output', err);
-                    res.sendStatus(500);
-                } else if (result.matchedCount === 0) {
-                    self.logger.warn('posted output to job that did not exist');
-                    res.sendStatus(404);
-                } else {
-                    res.sendStatus(200);
-                }
             });
-        });
+            if (result.matchedCount === 0) {
+                self.logger.warn('posted output to job that did not exist');
+                res.sendStatus(404);
+            } else {
+                res.sendStatus(200);
+            }
+        } catch (err) {
+            self.logger.error('post output', err);
+            res.sendStatus(500);
+        }
     });
 
     // worker API
-    router.get('/worker', function (req, res/*, next*/) {
+    router.get('/worker', async function (req, res/*, next*/) {
         var response = {};
-        self.workerList.find({}).toArray(function (err, workers) {
-            var jobQuery = function (i) {
-                if (i === workers.length) {
-                    res.send(JSON.stringify(response));
-                    return;
-                }
-                var worker = workers[i];
-                self.jobList.find({
-                    status: 'RUNNING',
-                    worker: worker.clientId
-                }).sort({createTime: 1}).toArray(function (err, jobs) {
-                    // FIXME: index self.jobList on status?
-                    for (var j = 0; j < jobs.length; j += 1) {
-                        delete jobs[j]._id;
-                        delete jobs[j].secret;
-                    }
-                    delete worker._id;
-                    response[worker.clientId] = worker;
-                    response[worker.clientId].jobs = jobs;
+        const workers = await self.workerList.find({}).toArray();
+        for (let i = 0; i < workers.length; i++) {
+            const worker = workers[i];
+            const jobs = await self.jobList.find({
+                status: 'RUNNING',
+                worker: worker.clientId
+            }).sort({createTime: 1}).toArray();
+            for (var j = 0; j < jobs.length; j += 1) {
+                delete jobs[j]._id;
+                delete jobs[j].secret;
+            }
+            delete worker._id;
+            response[worker.clientId] = worker;
+            response[worker.clientId].jobs = jobs;
 
-                    jobQuery(i + 1);
-                });
-            };
-            jobQuery(0);
-        });
+        }
+        res.send(JSON.stringify(response));
     });
 
-    router.post('/worker', function (req, res/*, next*/) {
+    router.post('/worker', async function (req, res/*, next*/) {
         var clientRequest = new WorkerInfo.ClientRequest(req.body),
             serverResponse = new WorkerInfo.ServerResponse({refreshPeriod: workerRefreshInterval});
 
         serverResponse.labelJobs = self.labelJobs;
 
-        function checkForCanceledJobs() {
-            getCanceledJobs(clientRequest.runningJobs)
-                .then(function (jobsToCancel) {
-                    serverResponse.jobsToCancel = jobsToCancel;
-                    res.send(JSON.stringify(serverResponse));
-                })
-                .catch(function (err) {
-                    self.logger.error(err);
-                    res.send(JSON.stringify(serverResponse));
-                });
-        }
-
-        self.workerList.updateOne({clientId: clientRequest.clientId}, {
-            $set: {
-                lastSeen: (new Date()).getTime() / 1000,
-                labels: clientRequest.labels
-            }
-        }, {upsert: true}, function () {
+        try {
+            await self.workerList.updateOne({clientId: clientRequest.clientId}, {
+                $set: {
+                    lastSeen: (new Date()).getTime() / 1000,
+                    labels: clientRequest.labels
+                }
+            }, {upsert: true});  // TODO: Error handling?
             if (!self.running) {
                 self.logger.debug('ExecutorServer had been stopped.');
-                res.sendStatus(404);
+                return res.sendStatus(404);
             } else if (clientRequest.availableProcesses) {
-                self.jobList.find({
+                const docs = await self.jobList.find({
                     status: 'CREATED',
                     labels: {
                         $not: {
@@ -596,40 +530,31 @@ function ExecutorServer(options) {
                             }
                         }
                     }
-                }).limit(clientRequest.availableProcesses).toArray(function (err, docs) {
-                    if (err) {
-                        self.logger.error(err);
-                        res.sendStatus(500);
-                        return; // FIXME need to return 2x
-                    }
-
-                    var callback = function (i) {
-                        if (i === docs.length) {
-                            checkForCanceledJobs();
-                            return;
+                }).limit(clientRequest.availableProcesses).toArray();
+                for (let i = 0; i < docs.length; i++) {
+                    const numReplaced = await self.jobList.updateOne({_id: docs[i]._id, status: 'CREATED'}, {
+                        $set: {
+                            status: 'RUNNING',
+                            worker: clientRequest.clientId
                         }
-                        self.jobList.updateOne({_id: docs[i]._id, status: 'CREATED'}, {
-                            $set: {
-                                status: 'RUNNING',
-                                worker: clientRequest.clientId
-                            }
-                        }, function (err, numReplaced) {
-                            if (err) {
-                                self.logger.error(err);
-                                res.sendStatus(500);
-                                return;
-                            } else if (numReplaced) {
-                                serverResponse.jobsToStart.push(docs[i].hash);
-                            }
-                            callback(i + 1);
-                        });
-                    };
-                    callback(0);
-                });
-            } else {
-                checkForCanceledJobs();
+                    });
+                    if (numReplaced) {
+                        serverResponse.jobsToStart.push(docs[i].hash);
+                    }
+                }
             }
-        });
+
+            try {
+                const jobsToCancel = await getCanceledJobs(clientRequest.runningJobs);
+                serverResponse.jobsToCancel = jobsToCancel;
+            } catch (err) {
+                self.logger.error(err);
+            }
+            res.send(JSON.stringify(serverResponse));
+        } catch (err) {
+            self.logger.error(err);
+            res.sendStatus(500);
+        }
     });
 
     /**
@@ -643,9 +568,9 @@ function ExecutorServer(options) {
         var mongo = params.mongoClient;
         self.logger.debug('Starting executor');
         return Q.all([
-            Q.ninvoke(mongo, 'collection', JOB_LIST),
-            Q.ninvoke(mongo, 'collection', WORKER_LIST),
-            Q.ninvoke(mongo, 'collection', OUTPUT_LIST)
+            mongo.collection(JOB_LIST),
+            mongo.collection(WORKER_LIST),
+            mongo.collection(OUTPUT_LIST)
         ])
             .then(function (res) {
                 self.jobList = res[0];
@@ -653,9 +578,9 @@ function ExecutorServer(options) {
                 self.outputList = res[2];
                 if (self.gmeConfig.executor.clearOldDataAtStartUp === true) {
                     return Q.allSettled([
-                        Q.ninvoke(mongo, 'dropCollection', JOB_LIST),
-                        Q.ninvoke(mongo, 'dropCollection', WORKER_LIST),
-                        Q.ninvoke(mongo, 'dropCollection', OUTPUT_LIST)
+                        mongo.dropCollection(JOB_LIST),
+                        mongo.dropCollection(WORKER_LIST),
+                        mongo.dropCollection(OUTPUT_LIST)
                     ]);
                 }
             })
@@ -663,7 +588,7 @@ function ExecutorServer(options) {
                 watchLabelJobs();
                 workerTimeoutIntervalId = setInterval(workerTimeout, 10 * 1000);
                 self.running = true;
-                return Q.ninvoke(self.jobList, 'createIndex', {hash: 1}, {unique: true});
+                return self.jobList.createIndex({hash: 1}, {unique: true});
             })
             .nodeify(callback);
     };

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -464,12 +464,13 @@ ExecutorMaster.prototype.updateJob = async function (userId, info) {
 };
 
 ExecutorMaster.prototype.startClearOutputTimer = async function (jobInfo) {
-    var timeoutObj;
+    var self = this,
+        timeoutObj;
 
     timeoutObj = setTimeout(function () {
 
-        delete this.clearOutputsTimers[jobInfo.hash];
-        this.clearOutput(jobInfo);
+        delete self.clearOutputsTimers[jobInfo.hash];
+        self.clearOutput(jobInfo);
 
     }, this.gmeConfig.executor.clearOutputTimeout);
 

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -564,7 +564,7 @@ ExecutorMaster.prototype.getWorkerDict = async function (userId) {
     return dict;
 };
 
-ExecutorMaster.prototype.updateWorker = async function (userId, clientId, labels=[]) {
+ExecutorMaster.prototype.updateWorker = async function (userId, clientId, labels = []) {
     const query = {clientId};
     await this.workerList.updateOne(query, {
         $set: {
@@ -575,7 +575,7 @@ ExecutorMaster.prototype.updateWorker = async function (userId, clientId, labels
     }, {upsert: true});
 };
 
-ExecutorMaster.prototype.startQueuedJobs = async function (userId, clientId, labels=[], count=10) {
+ExecutorMaster.prototype.startQueuedJobs = async function (userId, clientId, labels = [], count = 10) {
     const startedHashes = [];
     const docs = await this.jobList.find({
         status: 'CREATED',

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -657,11 +657,12 @@ ExecutorMaster.prototype.clearOutput = async function (jobInfo) {
 };
 
 ExecutorMaster.prototype.stop = function () {
-    var timerIds = Object.keys(this.clearOutputsTimers);
+    const self = this;
+    const timerIds = Object.keys(this.clearOutputsTimers);
     timerIds.forEach(function (timerId) {
-        clearTimeout(this.clearOutputsTimers[timerId].timeoutObj);
-        this.logger.warn('Outputs will not be cleared for job', timerId,
-            this.clearOutputsTimers[timerId].jobInfo.outputNumber);
+        clearTimeout(self.clearOutputsTimers[timerId].timeoutObj);
+        self.logger.warn('Outputs will not be cleared for job', timerId,
+            self.clearOutputsTimers[timerId].jobInfo.outputNumber);
     });
     this.running = false;
     clearInterval(this.workerTimeoutIntervalId);

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -324,10 +324,10 @@ function ExecutorServer(options) {
 ExecutorServer.prototype.setUserFromToken = async function (req, res, next) {
     const {guestAccount} = this.gmeConfig.authentication;
     const userId = this.getUserId(req);
-    const isAuthenticated = !userId || userId === guestAccount;
+    const isNotAuthenticated = !userId || userId === guestAccount;
     const token = req.headers['x-api-token'];
 
-    if (!isAuthenticated && !!token) {
+    if (isNotAuthenticated && !!token) {
         req.userData = {
             userId: await this.accessTokens.getUserId(token)
         };

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -705,6 +705,7 @@ function StandAloneServer(gmeConfig) {
     __tokenServer = new TokenServer(middlewareOpts);
     __app.use('/rest/tokens', __tokenServer.router);
     middlewareOpts.accessTokens = __tokenServer.tokens;
+
     if (gmeConfig.executor.enable) {
         __executorServer = new ExecutorServer(middlewareOpts);
         __app.use('/rest/executor', __executorServer.router);

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -119,6 +119,7 @@ function StandAloneServer(gmeConfig) {
         // __requestCounter = 0,
         // __reportedRequestCounter = 0,
         // __requestCheckInterval = 2500,
+        __tokenServer,
         __executorServer,
         middlewareOpts;
 
@@ -701,7 +702,7 @@ function StandAloneServer(gmeConfig) {
     __app.use(methodOverride());
     __app.use(multipart({defer: true})); // required to upload files. (body parser should not be used!)
 
-    var __tokenServer = new TokenServer(middlewareOpts);
+    __tokenServer = new TokenServer(middlewareOpts);
     __app.use('/rest/tokens', __tokenServer.router);
     middlewareOpts.accessTokens = __tokenServer.tokens;
     if (gmeConfig.executor.enable) {

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -31,6 +31,7 @@ var path = require('path'),
     // Middleware
     BlobServer = require('./middleware/blob/BlobServer'),
     ExecutorServer = require('./middleware/executor/ExecutorServer'),
+    TokenServer = require('./middleware/access-tokens/TokenServer'),
     api = require('./api'),
 
     getClientConfig = require('../../config/getclientconfig'),
@@ -237,6 +238,9 @@ function StandAloneServer(gmeConfig) {
 
                 if (__executorServer) {
                     promises.push(__executorServer.start({mongoClient: db}));
+                }
+                if (__tokenServer) {
+                    promises.push(__tokenServer.start({mongoClient: db}));
                 }
 
                 return Q.all(promises);
@@ -697,7 +701,11 @@ function StandAloneServer(gmeConfig) {
     __app.use(methodOverride());
     __app.use(multipart({defer: true})); // required to upload files. (body parser should not be used!)
 
+    var __tokenServer = new TokenServer(middlewareOpts);
+    __app.use('/rest/tokens', __tokenServer.router);
+    middlewareOpts.accessTokens = __tokenServer.tokens;
     if (gmeConfig.executor.enable) {
+        // TODO: Create the access token server
         __executorServer = new ExecutorServer(middlewareOpts);
         __app.use('/rest/executor', __executorServer.router);
     } else {

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -705,7 +705,6 @@ function StandAloneServer(gmeConfig) {
     __app.use('/rest/tokens', __tokenServer.router);
     middlewareOpts.accessTokens = __tokenServer.tokens;
     if (gmeConfig.executor.enable) {
-        // TODO: Create the access token server
         __executorServer = new ExecutorServer(middlewareOpts);
         __app.use('/rest/executor', __executorServer.router);
     } else {

--- a/test/server/middleware/access-tokens/Tokens.spec.js
+++ b/test/server/middleware/access-tokens/Tokens.spec.js
@@ -1,7 +1,7 @@
 /*eslint-env node, mocha*/
 
 const testFixture = require('../../../_globals.js');
-describe('TokenServer', function() {
+describe('TokenServer', function () {
     const assert = require('assert');
     const {promisify} = require('util');
     const agent = testFixture.superagent.agent();

--- a/test/server/middleware/access-tokens/Tokens.spec.js
+++ b/test/server/middleware/access-tokens/Tokens.spec.js
@@ -1,0 +1,87 @@
+/*eslint-env node, mocha*/
+
+const testFixture = require('../../../_globals.js');
+describe('TokenServer', function() {
+    const assert = require('assert');
+    const {promisify} = require('util');
+    const agent = testFixture.superagent.agent();
+
+    let gmeConfig,
+        baseUrl,
+        server;
+
+    beforeEach(async function () {
+        gmeConfig = testFixture.getGmeConfig();
+        await testFixture.clearDatabase(gmeConfig);
+        server = testFixture.WebGME.standaloneServer(gmeConfig);
+        server.start = promisify(server.start);
+        server.stop = promisify(server.stop);
+        await server.start();
+        baseUrl = server.getUrl();
+    });
+
+    afterEach(async function () {
+        if (server) {
+            await server.stop();
+            server = null;
+        }
+    });
+
+    it('should be able to request access tokens', async function () {
+        const response = await createToken();
+        assert.equal(response.status, 200);
+        assert(response.body.userId, 'Did not set userId');
+    });
+
+    it('should be able to list access tokens', async function () {
+        await createToken();
+        await createToken();
+        const res = await listTokens();
+        assert.equal(res.status, 200);
+        const tokens = res.body;
+        assert.equal(tokens.length, 2);
+    });
+
+    it('should be able to delete access tokens', async function () {
+        await createToken();
+        const {body: token} = await createToken();
+        await deleteToken(token.id);
+        const res = await listTokens();
+        assert.equal(res.status, 200);
+        const tokens = res.body;
+        assert.equal(tokens.length, 1);
+    });
+
+    function createToken() {
+        return new Promise(function (resolve, reject) {
+            agent.post(baseUrl + '/rest/tokens/create').end(function (err, res) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(res);
+            });
+        });
+    }
+
+    function deleteToken(id) {
+        return new Promise(function (resolve, reject) {
+            agent.delete(baseUrl + '/rest/tokens/' + id).end(function (err, res) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(res);
+            });
+        });
+    }
+
+    function listTokens() {
+        return new Promise(function (resolve, reject) {
+            agent.get(baseUrl + '/rest/tokens/').end(function (err, res) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(res);
+            });
+        });
+    }
+});

--- a/test/server/middleware/executor/Executor.spec.js
+++ b/test/server/middleware/executor/Executor.spec.js
@@ -3,314 +3,456 @@
  * @author pmeijer / https://github.com/pmeijer
  */
 
-var testFixture = require('../../../_globals.js');
+const testFixture = require('../../../_globals.js');
 
 describe('ExecutorServer', function () {
     'use strict';
 
-    var gmeConfig,
-        agent = testFixture.superagent.agent(),
-        should = testFixture.should,
-        expect = testFixture.expect,
-        Q = testFixture.Q,
+    const assert = require('assert').strict;
+    const agent = testFixture.superagent.agent();
+    const {expect, Q} = testFixture;
+    let gmeConfig,
         server;
 
-    beforeEach(async function () {
-        await Q.allDone([
-            Q.ninvoke(testFixture, 'rimraf', './test-tmp/executor'),
-            Q.ninvoke(testFixture, 'rimraf', './test-tmp/executor-tmp')
-        ]);
-        gmeConfig = testFixture.getGmeConfig();
-        gmeConfig.executor.enable = true;
-        await testFixture.clearDatabase(gmeConfig);
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
-    });
-
-    afterEach(function (done) {
-        if (server) {
-            server.stop(done);
-        } else {
-            done();
-        }
-    });
-
-    it('should return 200 at rest/executor/worker/ with enableExecutor=true', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.get(serverBaseUrl + '/rest/executor/worker/').end(function (err, res) {
-                should.equal(res.status, 200, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 404 at rest/executor/worker/ with enableExecutor=false', function (done) {
-        gmeConfig.executor.enable = false;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.get(serverBaseUrl + '/rest/executor/worker/').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 200 GET rest/executor?status=SUCCESS', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.get(serverBaseUrl + '/rest/executor?status=SUCCESS').end(function (err, res) {
-                should.equal(res.status, 200, err);
-                expect(res.body).to.deep.equal({});
-                done();
-            });
-        });
-    });
-
-    it('should return 404 POST rest/executor/info', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/info').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 404 GET rest/executor/info/', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.get(serverBaseUrl + '/rest/executor/info/').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 404 GET rest/executor/info/does_not_exist', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.get(serverBaseUrl + '/rest/executor/info/does_not_exist').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-
-    it('should return 404 GET rest/executor/unknown_command', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.get(serverBaseUrl + '/rest/executor/unknown_command').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-
-    it('should return 404 PUT rest/executor/worker', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.put(serverBaseUrl + '/rest/executor/worker').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 404 PUT rest/executor/update', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.put(serverBaseUrl + '/rest/executor/update').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 404 POST rest/executor/update/does_not_exist', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/update/does_not_exist').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 404 PUT rest/executor/create', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.put(serverBaseUrl + '/rest/executor/create').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 404 POST rest/executor/create', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/create').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 200 POST rest/executor/create/some_hash', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
-                should.equal(res.status, 200, err);
-                should.equal(typeof res.body.secret, 'string', res.body);
-                done();
-            });
-        });
-    });
-
-    it('should set userId in created job rest/executor/create/some_hash', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
-                should.equal(res.body.userId.length, 1);
-                done();
-            });
-        });
-    });
-
-    it('should return 200 POST rest/executor/create/some_hash but no secret on second create', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
-                should.equal(res.status, 200, err);
-                should.equal(typeof res.body.secret, 'string', res.body);
-                agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
-                    should.equal(res.status, 200, err);
-                    should.equal(typeof res.body.secret, 'undefined', res.body.secret);
-                    done();
-                });
-            });
-        });
-    });
-
-    it('should return 404 POST rest/executor/cancel/hashDoesNotExist', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/cancel/hashDoesNotExist').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
-        });
-    });
-
-    it('should return 403 POST rest/executor/cancel/existingHash with no body', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
-                should.equal(res.status, 200, err);
-                agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash').end(function (err, res) {
-                    should.equal(res.status, 403, err);
-                    done();
-                });
-            });
-        });
-    });
-
-    it('should return 403 POST rest/executor/cancel/existingHash with wrong secret', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
-                should.equal(res.status, 200, err);
-                agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash')
-                    .send({secret: 'bla_bla'})
-                    .end(function (err, res) {
-                        should.equal(res.status, 403, err);
-                        done();
-                    });
-            });
-        });
-    });
-
-    it('should return 200 POST rest/executor/cancel/existingHash with correct secret', function (done) {
-        server.start(function () {
-            var serverBaseUrl = server.getUrl();
-            agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
-                should.equal(res.status, 200, err);
-                agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash')
-                    .send({secret: res.body.secret})
-                    .end(function (err, res) {
-                        should.equal(res.status, 200, err);
-                        agent.get(serverBaseUrl + '/rest/executor/info/existingHash')
-                            .end(function (err, res) {
-                                should.equal(res.status, 200, err);
-                                done();
-                            });
-                    });
-            });
-        });
-    });
-
-    describe('auth', function () {
-        beforeEach(() => {
-            gmeConfig.executor.authentication.enable = true;
-            gmeConfig.executor.authentication.allowGuests = true;
+    describe('REST API', function () {
+        beforeEach(async function () {
+            await Q.allDone([
+                Q.ninvoke(testFixture, 'rimraf', './test-tmp/executor'),
+                Q.ninvoke(testFixture, 'rimraf', './test-tmp/executor-tmp')
+            ]);
+            gmeConfig = testFixture.getGmeConfig();
+            gmeConfig.executor.enable = true;
+            await testFixture.clearDatabase(gmeConfig);
             server = testFixture.WebGME.standaloneServer(gmeConfig);
         });
 
-        it('should list jobs for the given user', function (done) {
-            // TODO: How can I add access tokens?
+        afterEach(function (done) {
+            if (server) {
+                server.stop(done);
+            } else {
+                done();
+            }
+        });
+
+        it('should return 200 at rest/executor/worker/ with enableExecutor=true', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.get(serverBaseUrl + '/rest/executor/worker/').end(function (err, res) {
+                    assert.equal(res.status, 200, err);
+                    done();
+                });
+            });
+        });
+
+        it('should return 404 at rest/executor/worker/ with enableExecutor=false', function (done) {
+            gmeConfig.executor.enable = false;
+            server = testFixture.WebGME.standaloneServer(gmeConfig);
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.get(serverBaseUrl + '/rest/executor/worker/').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
+        });
+
+        it('should return 200 GET rest/executor?status=SUCCESS', function (done) {
             server.start(function () {
                 var serverBaseUrl = server.getUrl();
                 agent.get(serverBaseUrl + '/rest/executor?status=SUCCESS').end(function (err, res) {
-                    should.equal(res.status, 200, err);
+                    assert.equal(res.status, 200, err);
                     expect(res.body).to.deep.equal({});
                     done();
                 });
             });
         });
 
-        it.skip('should not list jobs for other users', function (done) {
+        it('should return 404 POST rest/executor/info', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/info').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
-        it.skip('should return 200 if on post output w/ permissions', function (done) {
+        it('should return 404 GET rest/executor/info/', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.get(serverBaseUrl + '/rest/executor/info/').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
-        it.skip('should return 403 if on post output w/o permissions', function (done) {
+        it('should return 404 GET rest/executor/info/does_not_exist', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.get(serverBaseUrl + '/rest/executor/info/does_not_exist').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
-        it.skip('should return job info for user jobs', function (done) {
+
+        it('should return 404 GET rest/executor/unknown_command', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.get(serverBaseUrl + '/rest/executor/unknown_command').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
-        it.skip('should return 404 for job info w/o permissions', function (done) {
+
+        it('should return 404 PUT rest/executor/worker', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.put(serverBaseUrl + '/rest/executor/worker').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
-        it.skip('should create jobs with userId', function (done) {
+        it('should return 404 PUT rest/executor/update', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.put(serverBaseUrl + '/rest/executor/update').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
-        it.skip('should return 404 when canceling w/o permissions', function (done) {
+        it('should return 404 POST rest/executor/update/does_not_exist', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/update/does_not_exist').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
-        it.skip('should list workers for the given user', function (done) {
+        it('should return 404 PUT rest/executor/create', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.put(serverBaseUrl + '/rest/executor/create').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
-        it.skip('should not list workers for other users', function (done) {
-        });
-
-        // If guest accounts not allowed:
-        it.skip('should return 403 for job creation w/o token', function (done) {
+        it('should return 404 POST rest/executor/create', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/create').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
         });
 
         it('should return 200 POST rest/executor/create/some_hash', function (done) {
             server.start(function () {
                 var serverBaseUrl = server.getUrl();
                 agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
-                    should.equal(res.status, 200, err);
-                    should.equal(typeof res.body.secret, 'string', res.body);
+                    assert.equal(res.status, 200, err);
+                    assert.equal(typeof res.body.secret, 'string', res.body);
                     done();
                 });
             });
+        });
+
+        it('should set userId in created job rest/executor/create/some_hash', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
+                    assert.equal(res.body.userId.length, 1);
+                    done();
+                });
+            });
+        });
+
+        it('should return 200 POST rest/executor/create/some_hash but no secret on second create', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
+                    assert.equal(res.status, 200, err);
+                    assert.equal(typeof res.body.secret, 'string', res.body);
+                    agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
+                        assert.equal(res.status, 200, err);
+                        assert.equal(
+                            typeof res.body.secret,
+                            'undefined',
+                            `Expected no secret. Found "${res.body.secret}"`
+                        );
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should return 404 POST rest/executor/cancel/hashDoesNotExist', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/cancel/hashDoesNotExist').end(function (err, res) {
+                    assert.equal(res.status, 404, err);
+                    done();
+                });
+            });
+        });
+
+        it('should return 403 POST rest/executor/cancel/existingHash with no body', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
+                    assert.equal(res.status, 200, err);
+                    agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash').end(function (err, res) {
+                        assert.equal(res.status, 403, err);
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should return 403 POST rest/executor/cancel/existingHash with wrong secret', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
+                    assert.equal(res.status, 200, err);
+                    agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash')
+                        .send({secret: 'bla_bla'})
+                        .end(function (err, res) {
+                            assert.equal(res.status, 403, err);
+                            done();
+                        });
+                });
+            });
+        });
+
+        it('should return 200 POST rest/executor/cancel/existingHash with correct secret', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
+                    assert.equal(err, null);
+                    assert.equal(res.status, 200, err);
+                    agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash')
+                        .send({secret: res.body.secret})
+                        .end(function (err, res) {
+                            assert.equal(err, null, err);
+                            assert.equal(res.status, 200, err);
+                            agent.get(serverBaseUrl + '/rest/executor/info/existingHash')
+                                .end(function (err, res) {
+                                    assert.equal(res.status, 200, err);
+                                    done();
+                                });
+                        });
+                });
+            });
+        });
+
+        it('should return 403 for job creation w/o token (if no guests)', function (done) {
+            gmeConfig.executor.authentication.allowGuests = false;
+            server = testFixture.WebGME.standaloneServer(gmeConfig);
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.get(serverBaseUrl + '/rest/executor/create/').end(function (err, res) {
+                    assert.equal(res.status, 403, err);
+                    done();
+                });
+            });
+        });
+    });
+
+    describe('ExecutorMaster', function () {
+        const reqSrc = p => require('../../../../src/' + p);
+        const Express = require('express');
+        const ExecutorServer = reqSrc('server/middleware/executor/ExecutorServer');
+        const Logger = reqSrc('server/logger');
+        let app;
+
+        beforeEach(async () => {
+            gmeConfig = testFixture.getGmeConfig();
+            gmeConfig.executor.authentication.enable = true;
+            gmeConfig.executor.authentication.allowGuests = true;
+            const logger = Logger.createWithGmeConfig('gme', gmeConfig, true);
+            const middlewareOpts = {
+                gmeConfig,
+                logger,
+                ensureAuthenticated: (req, res, next) => next(),
+                getUserId: req => req.userData.userId,
+            };
+
+            const gmeAuth = await testFixture.clearDBAndGetGMEAuth(gmeConfig);
+            //const safeStorage = testFixture.getMemoryStorage(logger, gmeConfig, gmeAuth);
+            //const db = await safeStorage.openDatabase();
+            const db = await gmeAuth.connect();
+            server = new ExecutorServer(middlewareOpts);
+            app = new Express();
+            app.use(server.router);
+            await server.start({mongoClient: db});
+            app = await app.listen(gmeConfig.server.port);
+        });
+
+        afterEach(() => {
+            if (server) {
+                server.stop();
+            }
+            if (app) {
+                app.close();
+            }
+        });
+
+        it('should get userId in job info', async function () {
+            const hash = 'some_hash';
+            await server.master.createJob('brian', {hash});
+            const jobInfo = await server.master.getJobInfo('brian', hash);
+            assert(jobInfo.userId.includes('brian'));
+        });
+
+        it('should list jobs for the given user', async function () {
+            const hash = 'some_hash';
+            await server.master.createJob('brian', {hash});
+            const jobs = await server.master.getJobList('brian');
+            assert.notEqual(jobs[hash], undefined);
+        });
+
+        it('should not list jobs for other users', async function () {
+            const hash = 'some_hash';
+            await server.master.createJob('brian', {hash});
+            await server.master.createJob('bob', {hash: 'def'});
+            const jobs = await server.master.getJobList('brian');
+            assert.equal(jobs.def, undefined);
+        });
+
+        it('should not allow user to access other jobs', async function () {
+            const hash = 'some_hash';
+            await server.master.createJob('brian', {hash});
+            const canAccess = await server.master.canUserAccessJob('bob', hash);
+            assert.equal(canAccess, false);
+        });
+
+        it('should allow user to access own jobs', async function () {
+            const hash = 'some_hash';
+            await server.master.createJob('brian', {hash});
+            const canAccess = await server.master.canUserAccessJob('brian', hash);
+            assert.equal(canAccess, true);
+        });
+
+        it('should require correct secret when canceling jobs', async function () {
+            const hash = 'some_hash';
+            const {secret} = (await server.master.createJob('brian', {hash}));
+            await server.master.cancelJob('brian', hash, secret);
+        });
+
+        it('should not cancel job w/ invalid secret', async function () {
+            const hash = 'some_hash';
+            const secret = 'someSecret';
+            await server.master.createJob('brian', {hash, secret});
+            await assert.rejects(
+                () => server.master.cancelJob('brian', hash, 'hi'),
+                {message: 'Unauthorized'}
+            );
+        });
+
+        it('should list user workers', async function () {
+            const clientId = 'some_client_id';
+            await server.master.updateWorker('brian', clientId);
+            const workers = await server.master.getWorkerDict('brian');
+            assert(workers[clientId]);
+        });
+
+        it('should not list workers for other users', async function () {
+            const clientId = 'some_client_id';
+            await server.master.updateWorker('brian', clientId);
+            const workers = await server.master.getWorkerDict('bob');
+            assert(!workers[clientId]);
+        });
+
+        it('should get canceled jobs', async function () {
+            const hash = 'some_hash';
+            const {secret} = (await server.master.createJob('brian', {hash}));
+            await server.master.cancelJob('brian', hash, secret);
+            const jobs = await server.master.getCanceledJobs([hash]);
+            assert.equal(jobs[0], hash, 'Did not find canceled job');
+            assert.equal(jobs.length, 1, 'Found extra canceled jobs');
+        });
+
+        describe('startQueuedJobs', function () {
+            const userId = 'some_user';
+            const otherUserId = 'other_user';
+            const hash = 'some_hash';
+            const clientId = 'some_client_id';
+            let jobs;
+
+            beforeEach(async () => {
+                await server.master.updateWorker(userId, clientId);
+                await server.master.createJob(userId, {hash});
+                jobs = await server.master.startQueuedJobs(userId, clientId);
+            });
+
+            it('should start queued jobs', function () {
+                assert.equal(jobs[0], hash, 'Did not start job');
+            });
+
+            it('should update job info', async function () {
+                const jobInfo = await server.master.getJobInfo(userId, hash);
+                assert.equal(jobInfo.status, 'RUNNING');
+            });
+
+            it('should not run job on other user\'s workers', async function () {
+                await server.master.createJob(otherUserId, {hash: 'another_hash'});
+                jobs = await server.master.startQueuedJobs(clientId);
+                assert.equal(jobs.length, 0, 'Started job on another user\'s worker');
+            });
+        });
+
+        it('should update job output for user job', async function () {
+            const userId = 'some_user';
+            const hash = 'some_hash';
+            const outputInfo = {
+                hash,
+                outputNumber: 10,
+                data: 'hello'
+            };
+            await server.master.createJob(userId, {hash});
+            const count = await server.master.updateJobOutput(userId, hash, outputInfo);
+            assert.equal(count, 1);
+        });
+
+        it('should not update job output for other user\'s job', async function () {
+            const userId = 'some_user';
+            const otherUserId = 'other_user';
+            const hash = 'some_hash';
+            const outputInfo = {
+                hash,
+                outputNumber: 10,
+                data: 'hello'
+            };
+            await server.master.createJob(otherUserId, {hash});
+            const count = await server.master.updateJobOutput(userId, hash, outputInfo);
+            assert.equal(count, 0);
+        });
+
+        it('should get job output for user job', async function () {
+            const userId = 'some_user';
+            const hash = 'some_hash';
+            const outputInfo = {
+                hash,
+                outputNumber: 10,
+                data: 'hello'
+            };
+            await server.master.createJob(userId, {hash});
+            await server.master.updateJobOutput(userId, hash, outputInfo);
+            const outputs = await server.master.getJobOutput(userId, hash);
+            assert.equal(outputs.length, 1);
         });
     });
 });

--- a/test/server/middleware/executor/Executor.spec.js
+++ b/test/server/middleware/executor/Executor.spec.js
@@ -245,12 +245,71 @@ describe('ExecutorServer', function () {
                         agent.get(serverBaseUrl + '/rest/executor/info/existingHash')
                             .end(function (err, res) {
                                 should.equal(res.status, 200, err);
-                                server.stop(function (err) {
-                                    server = null;
-                                    done(err);
-                                });
+                                done();
                             });
                     });
+            });
+        });
+    });
+
+    describe('auth', function () {
+        beforeEach(() => {
+            gmeConfig.executor.authentication.enable = true;
+            gmeConfig.executor.authentication.allowGuests = true;
+            server = testFixture.WebGME.standaloneServer(gmeConfig);
+        });
+
+        it('should list jobs for the given user', function (done) {
+            // TODO: How can I add access tokens?
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.get(serverBaseUrl + '/rest/executor?status=SUCCESS').end(function (err, res) {
+                    should.equal(res.status, 200, err);
+                    expect(res.body).to.deep.equal({});
+                    done();
+                });
+            });
+        });
+
+        it.skip('should not list jobs for other users', function (done) {
+        });
+
+        it.skip('should return 200 if on post output w/ permissions', function (done) {
+        });
+
+        it.skip('should return 403 if on post output w/o permissions', function (done) {
+        });
+
+        it.skip('should return job info for user jobs', function (done) {
+        });
+
+        it.skip('should return 404 for job info w/o permissions', function (done) {
+        });
+
+        it.skip('should create jobs with userId', function (done) {
+        });
+
+        it.skip('should return 404 when canceling w/o permissions', function (done) {
+        });
+
+        it.skip('should list workers for the given user', function (done) {
+        });
+
+        it.skip('should not list workers for other users', function (done) {
+        });
+
+        // If guest accounts not allowed:
+        it.skip('should return 403 for job creation w/o token', function (done) {
+        });
+
+        it('should return 200 POST rest/executor/create/some_hash', function (done) {
+            server.start(function () {
+                var serverBaseUrl = server.getUrl();
+                agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
+                    should.equal(res.status, 200, err);
+                    should.equal(typeof res.body.secret, 'string', res.body);
+                    done();
+                });
             });
         });
     });

--- a/test/server/middleware/executor/Executor.spec.js
+++ b/test/server/middleware/executor/Executor.spec.js
@@ -15,16 +15,15 @@ describe('ExecutorServer', function () {
         Q = testFixture.Q,
         server;
 
-    beforeEach(function (done) {
-        Q.allDone([
+    beforeEach(async function () {
+        await Q.allDone([
             Q.ninvoke(testFixture, 'rimraf', './test-tmp/executor'),
             Q.ninvoke(testFixture, 'rimraf', './test-tmp/executor-tmp')
-        ])
-            .then(function () {
-                gmeConfig = testFixture.getGmeConfig();
-                return testFixture.clearDatabase(gmeConfig);
-            })
-            .nodeify(done);
+        ]);
+        gmeConfig = testFixture.getGmeConfig();
+        gmeConfig.executor.enable = true;
+        await testFixture.clearDatabase(gmeConfig);
+        server = testFixture.WebGME.standaloneServer(gmeConfig);
     });
 
     afterEach(function (done) {
@@ -36,16 +35,11 @@ describe('ExecutorServer', function () {
     });
 
     it('should return 200 at rest/executor/worker/ with enableExecutor=true', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.get(serverBaseUrl + '/rest/executor/worker/').end(function (err, res) {
                 should.equal(res.status, 200, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
@@ -57,186 +51,136 @@ describe('ExecutorServer', function () {
             var serverBaseUrl = server.getUrl();
             agent.get(serverBaseUrl + '/rest/executor/worker/').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 200 GET rest/executor?status=SUCCESS', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.get(serverBaseUrl + '/rest/executor?status=SUCCESS').end(function (err, res) {
                 should.equal(res.status, 200, err);
                 expect(res.body).to.deep.equal({});
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 404 POST rest/executor/info', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/info').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 404 GET rest/executor/info/', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.get(serverBaseUrl + '/rest/executor/info/').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 404 GET rest/executor/info/does_not_exist', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.get(serverBaseUrl + '/rest/executor/info/does_not_exist').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
 
     it('should return 404 GET rest/executor/unknown_command', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.get(serverBaseUrl + '/rest/executor/unknown_command').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
 
     it('should return 404 PUT rest/executor/worker', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.put(serverBaseUrl + '/rest/executor/worker').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 404 PUT rest/executor/update', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.put(serverBaseUrl + '/rest/executor/update').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 404 POST rest/executor/update/does_not_exist', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/update/does_not_exist').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 404 PUT rest/executor/create', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.put(serverBaseUrl + '/rest/executor/create').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 404 POST rest/executor/create', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/create').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 200 POST rest/executor/create/some_hash', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
                 should.equal(res.status, 200, err);
                 should.equal(typeof res.body.secret, 'string', res.body);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
+            });
+        });
+    });
+
+    it('should set userId in created job rest/executor/create/some_hash', function (done) {
+        server.start(function () {
+            var serverBaseUrl = server.getUrl();
+            agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
+                should.equal(res.body.userId.length, 1);
+                done();
             });
         });
     });
 
     it('should return 200 POST rest/executor/create/some_hash but no secret on second create', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
@@ -245,51 +189,36 @@ describe('ExecutorServer', function () {
                 agent.post(serverBaseUrl + '/rest/executor/create/some_hash').end(function (err, res) {
                     should.equal(res.status, 200, err);
                     should.equal(typeof res.body.secret, 'undefined', res.body.secret);
-                    server.stop(function (err) {
-                        server = null;
-                        done(err);
-                    });
+                    done();
                 });
             });
         });
     });
 
     it('should return 404 POST rest/executor/cancel/hashDoesNotExist', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/cancel/hashDoesNotExist').end(function (err, res) {
                 should.equal(res.status, 404, err);
-                server.stop(function (err) {
-                    server = null;
-                    done(err);
-                });
+                done();
             });
         });
     });
 
     it('should return 403 POST rest/executor/cancel/existingHash with no body', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
                 should.equal(res.status, 200, err);
                 agent.post(serverBaseUrl + '/rest/executor/cancel/existingHash').end(function (err, res) {
                     should.equal(res.status, 403, err);
-                    server.stop(function (err) {
-                        server = null;
-                        done(err);
-                    });
+                    done();
                 });
             });
         });
     });
 
     it('should return 403 POST rest/executor/cancel/existingHash with wrong secret', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {
@@ -298,18 +227,13 @@ describe('ExecutorServer', function () {
                     .send({secret: 'bla_bla'})
                     .end(function (err, res) {
                         should.equal(res.status, 403, err);
-                        server.stop(function (err) {
-                            server = null;
-                            done(err);
-                        });
+                        done();
                     });
             });
         });
     });
 
     it('should return 200 POST rest/executor/cancel/existingHash with correct secret', function (done) {
-        gmeConfig.executor.enable = true;
-        server = testFixture.WebGME.standaloneServer(gmeConfig);
         server.start(function () {
             var serverBaseUrl = server.getUrl();
             agent.post(serverBaseUrl + '/rest/executor/create/existingHash').end(function (err, res) {


### PR DESCRIPTION
This PR adds support for authenticated executor workers. This restricts executors/users to:
- only see their own jobs/workers
- run their own jobs on their own workers

Authentication for the workers happens via personal access tokens which have also been added. The access tokens have been added to the `middlewareOpts` to make them available to the executor server (and potentially other middleware).

I have also refactored the executor server to try to separate the business logic from the REST API to make it easier to test.