### PR TITLE
Update access tokens to have "id" and "value". Closes #192

### DIFF
--- a/test/server/middleware/access-tokens/Tokens.spec.js
+++ b/test/server/middleware/access-tokens/Tokens.spec.js
@@ -48,21 +48,22 @@ describe('TokenServer', function () {
         assert.equal(tokens.length, 2);
     });
 
-    it('should token list should not include ID', async function () {
+    it('should token list should not include value', async function () {
         await createToken();
         await createToken();
         const res = await listTokens();
         assert.equal(res.status, 200);
         const tokens = res.body;
         tokens.forEach(token => {
-            assert(!token.id);
+            assert(!token.value);
         });
     });
 
     it('should be able to delete access tokens', async function () {
         await createToken();
-        const {body: token} = await createToken();
-        await deleteToken(token.id);
+        await createToken();
+        const {body: initialTokens} = await listTokens();
+        await deleteToken(initialTokens[0].id);
         const res = await listTokens();
         assert.equal(res.status, 200);
         const tokens = res.body;


### PR DESCRIPTION
This updates tokens to have both an "id" and "value" field. The "id" is public and corresponds to the _id field from mongodb; "value" is the token's secret.

This also updated the tests to catch errors like #192. That is, previously the test was deleting a newly created token. This has been updated to delete a token returned from a call to list the user's tokens.