### PR TITLE
Use (unique) display name for deletion. Fixes #192

### DIFF
--- a/src/server/middleware/access-tokens/TokenServer.js
+++ b/src/server/middleware/access-tokens/TokenServer.js
@@ -100,7 +100,7 @@ AccessTokens.prototype.create = async function (userId, name) {
         return token;
     } catch (err) {
         if (err.message.includes('duplicate key error')) {
-            throw new InvalidTokenError(`Token name already exists.`);
+            throw new InvalidTokenError('Token name already exists.');
         }
         throw err;
     }

--- a/test/server/middleware/access-tokens/Tokens.spec.js
+++ b/test/server/middleware/access-tokens/Tokens.spec.js
@@ -36,7 +36,18 @@ describe('TokenServer', function () {
     it('should be able to create access tokens w/ default display name', async function () {
         const response = await createToken();
         assert.equal(response.status, 200);
-        assert(response.body.displayName.startsWith('Created on'), 'Did not set userId');
+        assert(response.body.displayName.startsWith('Created on'), 'Did not set default display name');
+    });
+
+    it('should not be able to create access tokens w/ existing display name', async function () {
+        await createToken('hello');
+        try {
+            await createToken('hello');
+        } catch (response) {
+            assert.equal(response.status, 400);
+            return;
+        }
+        assert(false, 'Created token with duplicate name.');
     });
 
     it('should be able to list access tokens', async function () {
@@ -69,11 +80,11 @@ describe('TokenServer', function () {
         assert.equal(tokens.length, 1);
     });
 
-    function createToken() {
+    function createToken(name = '') {
         return new Promise(function (resolve, reject) {
-            agent.post(baseUrl + '/rest/tokens/create').end(function (err, res) {
+            agent.post(`${baseUrl}/rest/tokens/create/${name}`).end(function (err, res) {
                 if (err) {
-                    return reject(err);
+                    return reject(res);
                 }
                 resolve(res);
             });

--- a/test/server/middleware/access-tokens/Tokens.spec.js
+++ b/test/server/middleware/access-tokens/Tokens.spec.js
@@ -62,7 +62,7 @@ describe('TokenServer', function () {
     it('should be able to delete access tokens', async function () {
         await createToken();
         const {body: token} = await createToken();
-        await deleteToken(token.id);
+        await deleteToken(token.displayName);
         const res = await listTokens();
         assert.equal(res.status, 200);
         const tokens = res.body;


### PR DESCRIPTION
This PR updates the tokens to have unique display names and then uses them for deletion.