### PR TITLE
Add API token auth to blob. Minor refactor of executor api token auth

### DIFF
--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -64,6 +64,7 @@ define([
             this.server = parameters.server || this.server;
             this.serverPort = parameters.serverPort || this.serverPort;
             this.httpsecure = (parameters.httpsecure !== undefined) ? parameters.httpsecure : this.httpsecure;
+            this.apiToken = parameters.apiToken;
             this.webgmeToken = parameters.webgmeToken;
             this.keepaliveAgentOptions = parameters.keepaliveAgentOptions || {/* use defaults */};
         } else {
@@ -212,6 +213,10 @@ define([
             req.agent(this.keepaliveAgent);
         }
 
+        if (this.apiToken) {
+            req.set('x-api-token', this.apiToken);
+        }
+
         if (this.webgmeToken) {
             req.set('Authorization', 'Bearer ' + this.webgmeToken);
         }
@@ -258,6 +263,10 @@ define([
         }
 
         req = superagent.post(this.getCreateURL(metadataDescriptor.name, true));
+        if (this.apiToken) {
+            req.set('x-api-token', this.apiToken);
+        }
+
         if (this.webgmeToken) {
             req.set('Authorization', 'Bearer ' + this.webgmeToken);
         }
@@ -366,6 +375,10 @@ define([
         //superagent.parse['application/json'] = superagent.parse['application/zip'];
 
         var req = superagent.get(this.getViewURL(metadataHash, subpath));
+        if (this.apiToken) {
+            req.set('x-api-token', this.apiToken);
+        }
+
         if (this.webgmeToken) {
             req.set('Authorization', 'Bearer ' + this.webgmeToken);
         }
@@ -460,6 +473,10 @@ define([
 
         var req = superagent.get(this.getViewURL(metadataHash, subpath));
 
+        if (this.apiToken) {
+            req.set('x-api-token', this.apiToken);
+        }
+
         if (this.webgmeToken) {
             req.set('Authorization', 'Bearer ' + this.webgmeToken);
         }
@@ -543,6 +560,10 @@ define([
             self = this;
 
         this.logger.debug('getMetadata', metadataHash);
+
+        if (this.apiToken) {
+            req.set('x-api-token', this.apiToken);
+        }
 
         if (this.webgmeToken) {
             req.set('Authorization', 'Bearer ' + this.webgmeToken);

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -213,13 +213,7 @@ define([
             req.agent(this.keepaliveAgent);
         }
 
-        if (this.apiToken) {
-            req.set('x-api-token', this.apiToken);
-        }
-
-        if (this.webgmeToken) {
-            req.set('Authorization', 'Bearer ' + this.webgmeToken);
-        }
+        this._setAuthHeaders(req);
 
         if (typeof data !== 'string' && !(data instanceof String) && typeof window === 'undefined') {
             req.set('Content-Length', contentLength);
@@ -245,6 +239,14 @@ define([
         return deferred.promise.nodeify(callback);
     };
 
+    BlobClient.prototype._setAuthHeaders = function (req) {
+        if (this.apiToken) {
+            req.set('x-api-token', this.apiToken);
+        } else if (this.webgmeToken) {
+            req.set('Authorization', 'Bearer ' + this.webgmeToken);
+        }
+    };
+
     BlobClient.prototype.putMetadata = function (metadataDescriptor, callback) {
         var metadata = new BlobMetadata(metadataDescriptor),
             deferred = Q.defer(),
@@ -263,13 +265,7 @@ define([
         }
 
         req = superagent.post(this.getCreateURL(metadataDescriptor.name, true));
-        if (this.apiToken) {
-            req.set('x-api-token', this.apiToken);
-        }
-
-        if (this.webgmeToken) {
-            req.set('Authorization', 'Bearer ' + this.webgmeToken);
-        }
+        this._setAuthHeaders(req);
 
         if (typeof window === 'undefined') {
             req.agent(this.keepaliveAgent);
@@ -375,13 +371,7 @@ define([
         //superagent.parse['application/json'] = superagent.parse['application/zip'];
 
         var req = superagent.get(this.getViewURL(metadataHash, subpath));
-        if (this.apiToken) {
-            req.set('x-api-token', this.apiToken);
-        }
-
-        if (this.webgmeToken) {
-            req.set('Authorization', 'Bearer ' + this.webgmeToken);
-        }
+        this._setAuthHeaders(req);
 
         if (typeof window === 'undefined') {
             // running on node
@@ -473,13 +463,7 @@ define([
 
         var req = superagent.get(this.getViewURL(metadataHash, subpath));
 
-        if (this.apiToken) {
-            req.set('x-api-token', this.apiToken);
-        }
-
-        if (this.webgmeToken) {
-            req.set('Authorization', 'Bearer ' + this.webgmeToken);
-        }
+        this._setAuthHeaders(req);
 
         if (typeof Buffer !== 'undefined') {
             // running on node
@@ -561,13 +545,7 @@ define([
 
         this.logger.debug('getMetadata', metadataHash);
 
-        if (this.apiToken) {
-            req.set('x-api-token', this.apiToken);
-        }
-
-        if (this.webgmeToken) {
-            req.set('Authorization', 'Bearer ' + this.webgmeToken);
-        }
+        this._setAuthHeaders(req);
 
         if (typeof window === 'undefined') {
             req.agent(this.keepaliveAgent);

--- a/src/server/middleware/access-tokens/TokenServer.js
+++ b/src/server/middleware/access-tokens/TokenServer.js
@@ -152,12 +152,13 @@ AccessTokens.prototype.setUserFromToken = async function (req, res, next) {
 
     if (token) {
         const userId = await this.getUserId(token);
-        console.log('setting user from token:', token, '(', userId, ')');
         req.userData = req.userData || {};
         req.userData.userId = userId;
     }
 
-    next();
+    if (next) {
+        next();
+    }
 };
 
 module.exports = TokenServer;

--- a/src/server/middleware/access-tokens/TokenServer.js
+++ b/src/server/middleware/access-tokens/TokenServer.js
@@ -14,7 +14,6 @@ const TOKEN_COLLECTION = '_tokenList';
  *
  * @param {object} options - middlewareOptions
  * @param {GmeLogger} options.logger - logger to fork off from
- * @param {GmeConfig} options.gmeConfig - gmeConfig
  * @param {function} options.ensureAuthenticated
  * @constructor
  * @ignore
@@ -147,5 +146,18 @@ AccessTokens.prototype.getUserId = async function (id) {
 function InvalidTokenError() {
     Error.apply(this, arguments);
 }
+
+AccessTokens.prototype.setUserFromToken = async function (req, res, next) {
+    const token = req.headers['x-api-token'];
+
+    if (token) {
+        const userId = await this.getUserId(token);
+        console.log('setting user from token:', token, '(', userId, ')');
+        req.userData = req.userData || {};
+        req.userData.userId = userId;
+    }
+
+    next();
+};
 
 module.exports = TokenServer;

--- a/src/server/middleware/blob/BlobServer.js
+++ b/src/server/middleware/blob/BlobServer.js
@@ -28,8 +28,10 @@ function createExpressBlob(options) {
     accessTokens = options.accessTokens;
     getUserId = options.getUserId;
     logger = options.logger.fork('middleware:BlobServer');
-    ensureAuthenticated = function (req, res, next) {
+    ensureAuthenticated = async function (req, res, next) {
         const {guestAccount, allowGuests} = options.gmeConfig.authentication;
+
+        await accessTokens.setUserFromToken(req, res);
         const userId = getUserId(req);
         const isGuest = userId === guestAccount;
         const isInvalidUser = isGuest && !allowGuests;
@@ -61,7 +63,6 @@ function createExpressBlob(options) {
         next();
     }); */
 
-    __app.use('*', accessTokens.setUserFromToken.bind(accessTokens));
     __app.get('/metadata', ensureAuthenticated, function (req, res) {
         if (options.gmeConfig.debug) {
             blobBackend.listAllMetadata(req.query.all, function (err, metadata) {

--- a/src/server/middleware/executor/ExecutorServer.js
+++ b/src/server/middleware/executor/ExecutorServer.js
@@ -79,6 +79,7 @@ function ExecutorServer(options) {
     async function executorAuthenticate(req, res, next) {
         let isAuth = true;
 
+        await self.accessTokens.setUserFromToken(req, res);
         self.ensureHasUserId(req);
         const needsUser = !self.gmeConfig.executor.authentication.allowGuests;
         if (needsUser && self.isGuestUserId(req)) {
@@ -136,7 +137,6 @@ function ExecutorServer(options) {
     });
 
     // all endpoints require authentication
-    router.use('*', self.accessTokens.setUserFromToken.bind(self.accessTokens));
     router.use('*', executorAuthenticate);
     router.use('/output/:hash', async function (req, res, next) {
         const {hash} = req.params;

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -321,7 +321,7 @@ function StandAloneServer(gmeConfig) {
 
         logger.debug('destroyed # of sockets: ' + numDestroyedSockets);
 
-        serverDeferred.promise
+        return serverDeferred.promise
             .then(function () {
                 var promises = [];
 

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -360,7 +360,7 @@ function StandAloneServer(gmeConfig) {
 
     //internal functions
     function getUserId(req) {
-        return req.userData.userId;
+        return req.userData && req.userData.userId;
     }
 
     function ensureAuthenticated(req, res, next) {

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -360,7 +360,7 @@ function StandAloneServer(gmeConfig) {
 
     //internal functions
     function getUserId(req) {
-        return req.userData && req.userData.userId;
+        return req.userData.userId;
     }
 
     function ensureAuthenticated(req, res, next) {

--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -351,7 +351,9 @@ function StandAloneServer(gmeConfig) {
                     logger.error('Error at server stop', err);
                 }
 
-                callback(err);
+                if (callback) {
+                    callback(err);
+                }
             });
     }
 

--- a/test/common/blob/BlobClient.spec.js
+++ b/test/common/blob/BlobClient.spec.js
@@ -1081,7 +1081,6 @@ describe('BlobClient', function () {
                     if (err) {
                         return reject(err);
                     }
-                    console.log(res.body);
                     resolve(res.body);
                 })
         );

--- a/test/server/middleware/executor/Executor.spec.js
+++ b/test/server/middleware/executor/Executor.spec.js
@@ -26,11 +26,9 @@ describe('ExecutorServer', function () {
             server = testFixture.WebGME.standaloneServer(gmeConfig);
         });
 
-        afterEach(function (done) {
+        afterEach(async function () {
             if (server) {
-                server.stop(done);
-            } else {
-                done();
+                await server.stop();
             }
         });
 
@@ -301,9 +299,9 @@ describe('ExecutorServer', function () {
             app = await app.listen(gmeConfig.server.port);
         });
 
-        afterEach(() => {
+        afterEach(async () => {
             if (server) {
-                server.stop();
+                await server.stop();
             }
             if (app) {
                 app.close();


### PR DESCRIPTION
This PR adds authentication using access tokens to the blob server (required for webgme executor workers to fetch the job itself). This included a minor refactor of the auth in executor server to avoid code duplication.