### PR TITLE
Optionally encrypt/decrypt userData fields using GME Auth. Closes #199

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -44,6 +44,10 @@ var path = require('path'),
                 algorithm: 'RS256',
                 // The private key is only needed if using the localtokengenerator
                 privateKey: path.join(__dirname, '../src/server/middleware/auth/EXAMPLE_PRIVATE_KEY')
+            },
+            encryption: {
+                algorithm: 'aes-256-cbc',
+                key: path.join(__dirname, '../src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY')
             }
         },
 

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -326,45 +326,65 @@ function createAPI(app, mountPath, middlewareOpts) {
             .catch(next);
     });
 
-    router.get('/user/data', ensureAuthenticated, function (req, res, next) {
-        var userId = getUserId(req);
+    router.get(/\/user\/data\/?(.*)/, ensureAuthenticated, function (req, res, next) {
+        const userId = getUserId(req);
+        const keys = getUserDataKeys(req);
+        const {decrypt = false} = req.query;
 
-        gmeAuth.getUser(userId)
-            .then(function (userData) {
-                res.json(userData.data);
-            })
-            .catch(next);
-    });
-
-    router.put('/user/data', function (req, res, next) {
-        var userId = getUserId(req);
-
-        gmeAuth.updateUserDataField(userId, req.body, true)
+        gmeAuth.getUserDataField(userId, keys, decrypt)
             .then(function (data) {
                 res.json(data);
             })
             .catch(next);
     });
 
-    router.patch('/user/data', function (req, res, next) {
-        var userId = getUserId(req);
+    router.put(/\/user\/data\/?(.*)/, function (req, res, next) {
+        const userId = getUserId(req);
+        const keys = getUserDataKeys(req);
+        const {encrypt = false} = req.query;
+        const options = {
+            encrypt,
+            overwrite: true
+        };
 
-        gmeAuth.updateUserDataField(userId, req.body)
+        gmeAuth.setUserDataField(userId, keys, req.body, options)
             .then(function (data) {
                 res.json(data);
             })
             .catch(next);
     });
 
-    router.delete('/user/data', function (req, res, next) {
-        var userId = getUserId(req);
+    router.patch(/\/user\/data\/?(.*)/, function (req, res, next) {
+        const userId = getUserId(req);
+        const keys = getUserDataKeys(req);
+        const {encrypt = false} = req.query;
+        const options = {
+            encrypt,
+            overwrite: false
+        };
 
-        gmeAuth.updateUserDataField(userId, {}, true)
+        gmeAuth.setUserDataField(userId, keys, req.body, options)
+            .then(function (data) {
+                res.json(data);
+            })
+            .catch(next);
+    });
+
+    router.delete(/\/user\/data\/?(.*)/, function (req, res, next) {
+        const userId = getUserId(req);
+        const keys = getUserDataKeys(req);
+
+        gmeAuth.setUserDataField(userId, keys)
             .then(function (/*data*/) {
                 res.sendStatus(204);
             })
             .catch(next);
     });
+
+    function getUserDataKeys(req) {
+        const encodedKeys = req.params[0].split('/');
+        return encodedKeys.map(decodeURIComponent);
+    }
 
     router.get('/user/token', ensureAuthenticated, function (req, res, next) {
         var userId = getUserId(req);

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -374,7 +374,7 @@ function createAPI(app, mountPath, middlewareOpts) {
         const userId = getUserId(req);
         const keys = getUserDataKeys(req);
 
-        gmeAuth.setUserDataField(userId, keys)
+        gmeAuth.deleteUserDataField(userId, keys)
             .then(function (/*data*/) {
                 res.sendStatus(204);
             })

--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -383,7 +383,16 @@ function createAPI(app, mountPath, middlewareOpts) {
 
     function getUserDataKeys(req) {
         const encodedKeys = req.params[0].split('/');
-        return encodedKeys.map(decodeURIComponent);
+        encodedKeys.map(decodeURIComponent);
+        let i = encodedKeys.length;
+        if (i > 0) {
+            while (i--) {
+                if (encodedKeys[i] === '') {
+                    encodedKeys.splice(i, 1);
+                }
+            }
+        }
+        return encodedKeys;
     }
 
     router.get('/user/token', ensureAuthenticated, function (req, res, next) {

--- a/src/server/api/webgme-api.raml
+++ b/src/server/api/webgme-api.raml
@@ -191,13 +191,13 @@ resourceTypes:
     put:
         queryParameters:
             encrypt:
-                description: 'Encrypt the submitted data.'
+                description: 'Encrypt the submitted data before saving.'
                 required: false
                 type: boolean
     patch:
         queryParameters:
             encrypt:
-                description: 'Encrypt the submitted data.'
+                description: 'Encrypt the submitted data before saving.'
                 required: false
                 type: boolean
     type:

--- a/src/server/api/webgme-api.raml
+++ b/src/server/api/webgme-api.raml
@@ -181,6 +181,25 @@ resourceTypes:
               application/json:
                 example: !include webgme-api-user-token.json
   /data:
+    description: Entity representing a datum. Nested values can be accessed via URI parameters such as `/user/data/key1/key2...`.
+    get:
+        queryParameters:
+            decrypt:
+                description: 'Decrypt the requested data.'
+                required: false
+                type: boolean
+    put:
+        queryParameters:
+            encrypt:
+                description: 'Encrypt the submitted data.'
+                required: false
+                type: boolean
+    patch:
+        queryParameters:
+            encrypt:
+                description: 'Encrypt the submitted data.'
+                required: false
+                type: boolean
     type:
       collection-item:
         exampleItem: !include webgme-api-user-data-retrieve.json

--- a/src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY
+++ b/src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY
@@ -1,1 +1,1 @@
-1234567890asdfghjklpoiuytrewqzxc
+1234567890asdfghjklpoiuytrewqzx

--- a/src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY
+++ b/src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY
@@ -1,0 +1,1 @@
+1234567890asdfghjklpoiuytrewqzxc

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -632,7 +632,6 @@ function GMEAuth(session, gmeConfig) {
     }
 
     function _decryptData(encrypted) {
-        // TODO: Handle these errors better
         const iv = Buffer.from(encrypted.iv, 'hex');
         const encryptedData = Buffer.from(encrypted.encryptedData, 'hex');
         const decipher = crypto.createDecipheriv(algorithm, key, iv);

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -564,7 +564,7 @@ function GMEAuth(session, gmeConfig) {
                 if (!userData) {
                     throw new Error('no such user [' + userId + ']');
                 } else if (!isValidValue) {
-                    throw new Error(`object required for ${jointKey}. Found [${newValue}]`);
+                    throw new Error(`object required for user ${jointKey}. Found [${newValue}]`);
                 }
 
                 currentValue = userData[keys.shift()] || {};

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -592,7 +592,6 @@ function GMEAuth(session, gmeConfig) {
                 const deleteNestedKey = currentValue === undefined;
                 const update = {};
                 if (deleteNestedKey) {
-                    console.log('deleting', jointKey);
                     update.$unset = {};
                     update.$unset[jointKey] = '';
                 } else {

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -736,12 +736,16 @@ function GMEAuth(session, gmeConfig) {
      * @param {function} [callback]
      * @returns {*}
      */
-    function updateUserComponentSettings(userId, componentId, settings, overwrite, callback) {
-        return _updateUserObjectField(userId, ['settings', componentId], settings, {overwrite})
-            .then(function (userData) {
-                return userData.settings[componentId];
-            })
-            .nodeify(callback);
+    async function updateUserComponentSettings(userId, componentId, settings, overwrite, callback) {
+        const deferred = Q.defer();
+        try {
+            const userData = await _updateUserObjectField(userId, ['settings', componentId], settings, {overwrite});
+            deferred.resolve(userData.settings[componentId]);
+        } catch (e) {
+            deferred.reject(e);
+        }
+        
+        return deferred.promise.nodeify(callback);
     }
 
     /**
@@ -752,12 +756,16 @@ function GMEAuth(session, gmeConfig) {
      * @param {function} [callback]
      * @returns {*}
      */
-    function updateUserSettings(userId, settings, overwrite, callback) {
-        return _updateUserObjectField(userId, ['settings'], settings, {overwrite})
-            .then(function (userData) {
-                return userData.settings;
-            })
-            .nodeify(callback);
+    async function updateUserSettings(userId, settings, overwrite, callback) {
+        const deferred = Q.defer();
+        try {
+            const userData = await _updateUserObjectField(userId, ['settings'], settings, {overwrite});
+            deferred.resolve(userData.settings);
+        } catch (e) {
+            deferred.reject(e);
+        }
+        
+        return deferred.promise.nodeify(callback);
     }
 
     /**

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -660,6 +660,7 @@ function GMEAuth(session, gmeConfig) {
     }
 
     function _removeTrailingAcks(text) {
+        /* eslint-disable-next-line no-control-regex */
         return text.replace(/\u0006+$/g, '');
     }
 

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -672,14 +672,13 @@ function GMEAuth(session, gmeConfig) {
      * @param {function} [callback]
      * @returns {*}
      */
-    async function updateUserDataField(userId, data, overwrite, callback) {
+    function updateUserDataField(userId, data, overwrite, callback) {
         const deferred = Q.defer();
-        try {
-            const userData = await _updateUserObjectField(userId, ['data'], data, {overwrite});
-            deferred.resolve(userData.data);
-        } catch (e) {
-            deferred.reject(e);
-        }
+        _updateUserObjectField(userId, ['data'], data, {overwrite})
+            .then((userData) => {
+                deferred.resolve(userData.data);
+            })
+            .catch(deferred.reject);
         
         return deferred.promise.nodeify(callback);
     }
@@ -736,14 +735,13 @@ function GMEAuth(session, gmeConfig) {
      * @param {function} [callback]
      * @returns {*}
      */
-    async function updateUserComponentSettings(userId, componentId, settings, overwrite, callback) {
+    function updateUserComponentSettings(userId, componentId, settings, overwrite, callback) {
         const deferred = Q.defer();
-        try {
-            const userData = await _updateUserObjectField(userId, ['settings', componentId], settings, {overwrite});
-            deferred.resolve(userData.settings[componentId]);
-        } catch (e) {
-            deferred.reject(e);
-        }
+        _updateUserObjectField(userId, ['settings', componentId], settings, {overwrite})
+            .then((userData) => {
+                deferred.resolve(userData.settings[componentId]);
+            })
+            .catch(deferred.reject);
         
         return deferred.promise.nodeify(callback);
     }
@@ -756,14 +754,13 @@ function GMEAuth(session, gmeConfig) {
      * @param {function} [callback]
      * @returns {*}
      */
-    async function updateUserSettings(userId, settings, overwrite, callback) {
+    function updateUserSettings(userId, settings, overwrite, callback) {
         const deferred = Q.defer();
-        try {
-            const userData = await _updateUserObjectField(userId, ['settings'], settings, {overwrite});
-            deferred.resolve(userData.settings);
-        } catch (e) {
-            deferred.reject(e);
-        }
+        _updateUserObjectField(userId, ['settings'], settings, {overwrite})
+            .then((userData) => {
+                deferred.resolve(userData.settings);
+            })
+            .catch(deferred.reject);
         
         return deferred.promise.nodeify(callback);
     }

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -672,12 +672,16 @@ function GMEAuth(session, gmeConfig) {
      * @param {function} [callback]
      * @returns {*}
      */
-    function updateUserDataField(userId, data, overwrite, callback) {
-        return _updateUserObjectField(userId, ['data'], data, {overwrite})
-            .then(function (userData) {
-                return userData.data;
-            })
-            .nodeify(callback);
+    async function updateUserDataField(userId, data, overwrite, callback) {
+        const deferred = Q.defer();
+        try {
+            const userData = await _updateUserObjectField(userId, ['data'], data, {overwrite});
+            deferred.resolve(userData.data);
+        } catch (e) {
+            deferred.reject(e);
+        }
+        
+        return deferred.promise.nodeify(callback);
     }
 
     async function setUserDataField(userId, fields, data, options = {}) {

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -552,7 +552,7 @@ function GMEAuth(session, gmeConfig) {
             .nodeify(callback);
     }
 
-    function _updateUserObjectField(userId, keys, newValue, options={}) {
+    function _updateUserObjectField(userId, keys, newValue, options = {}) {
         const isNestedField = keys.length > 1;
         const {overwrite, encrypt} = options;
         return collection.findOne({_id: userId, type: {$ne: CONSTANTS.ORGANIZATION}, disabled: {$ne: true}})

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -601,8 +601,8 @@ function GMEAuth(session, gmeConfig) {
             });
     }
 
-    const algorithm = 'aes-256-cbc';
-    const key = Buffer.from('1234567890asdfghjklpoiuytrewqzxc');  // TODO: Read key from config
+    const {algorithm} = gmeConfig.authentication.encryption;
+    const key = fs.readFileSync(gmeConfig.authentication.encryption.key);
     function _encrypt(input) {
         const type = typeof input;
         if (type === 'object') {

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -633,14 +633,14 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function updateUserDataField(userId, data, overwrite, callback) {
-        return _updateUserObjectField(userId, ['data'], data, overwrite)
+        return _updateUserObjectField(userId, ['data'], data, {overwrite})
             .then(function (userData) {
                 return userData.data;
             })
             .nodeify(callback);
     }
 
-    async function setUserDataField(userId, fields, data, options={}) {
+    async function setUserDataField(userId, fields, data, options = {}) {
         if (typeof fields === 'string') {
             fields = [fields];
         }
@@ -685,7 +685,7 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function updateUserComponentSettings(userId, componentId, settings, overwrite, callback) {
-        return _updateUserObjectField(userId, ['settings', componentId], settings, overwrite)
+        return _updateUserObjectField(userId, ['settings', componentId], settings, {overwrite})
             .then(function (userData) {
                 return userData.settings[componentId];
             })
@@ -701,7 +701,7 @@ function GMEAuth(session, gmeConfig) {
      * @returns {*}
      */
     function updateUserSettings(userId, settings, overwrite, callback) {
-        return _updateUserObjectField(userId, ['settings'], settings, overwrite)
+        return _updateUserObjectField(userId, ['settings'], settings, {overwrite})
             .then(function (userData) {
                 return userData.settings;
             })

--- a/test/plugin/coreplugins/coreplugins.spec.js
+++ b/test/plugin/coreplugins/coreplugins.spec.js
@@ -44,7 +44,8 @@ describe('CorePlugins', function () {
             'InvokedPlugin',
             'WaitingForAbort',
             'AbortPlugin',
-            'WaitPlugin'
+            'WaitPlugin',
+            'SearchNodes'
         ],
 
         pluginsShouldFail = [

--- a/test/server/middleware/auth/gmeauth.spec.js
+++ b/test/server/middleware/auth/gmeauth.spec.js
@@ -469,12 +469,30 @@ describe('GME authentication', function () {
             assert.deepEqual(userData.test, newData);
         });
 
+        it('should create objects as needed during set nested field ', async function () {
+            const newData = 10;
+            const keys = ['test-nested', 'a', 'b', 'c'];
+            await auth.setUserDataField(userId, keys, newData);
+            const data = await auth.getUserDataField(userId);
+            const value = keys.reduce((obj, key) => obj[key], data);
+            assert.equal(value, newData);
+        });
+
         it('should set/get encrypted field value', async function () {
             const newData = {hello: 'world'};
             const userData = await auth.setUserDataField(userId, 'test', newData, {encrypt: true});
-            const data = await auth.getUserDataField(userId, ['test', 'hello'], true);
-            assert.equal(data, newData.hello);
+            const data = await auth.getUserDataField(userId, 'test', true);
+            assert.deepEqual(data, newData);
             assert.notEqual(userData.test.hello, newData.hello);
+        });
+
+        it('should set/get encrypted string value', async function () {
+            const newData = 'testValue';
+            await auth.setUserDataField(userId, 'test', newData, {encrypt: true});
+            const encryptedData = await auth.getUserDataField(userId, 'test');
+            assert.notEqual(encryptedData, newData);
+            const data = await auth.getUserDataField(userId, 'test', true);
+            assert.equal(data, newData);
         });
 
         it('should set to non-object values', async function () {

--- a/test/server/middleware/auth/gmeauth.spec.js
+++ b/test/server/middleware/auth/gmeauth.spec.js
@@ -698,7 +698,7 @@ describe('GME authentication', function () {
                     throw new Error('Should have failed!');
                 })
                 .catch(function (err) {
-                    expect(err.message).to.include('supplied value is not an object [aString]');
+                    expect(err.message).to.include('object required for user data. Found [aString]');
                 })
                 .nodeify(done);
         });
@@ -715,7 +715,7 @@ describe('GME authentication', function () {
                     throw new Error('Should have failed!');
                 })
                 .catch(function (err) {
-                    expect(err.message).to.include('supplied value is not an object [null]');
+                    expect(err.message).to.include('object required for user data. Found [null]');
                 })
                 .nodeify(done);
         });
@@ -731,7 +731,7 @@ describe('GME authentication', function () {
                     throw new Error('Should have failed!');
                 })
                 .catch(function (err) {
-                    expect(err.message).to.include('supplied value is not an object [undefined]');
+                    expect(err.message).to.include('object required for user data. Found [undefined]');
                 })
                 .nodeify(done);
         });
@@ -747,7 +747,7 @@ describe('GME authentication', function () {
                     throw new Error('Should have failed!');
                 })
                 .catch(function (err) {
-                    expect(err.message).to.include('supplied value is not an object [1,2]');
+                    expect(err.message).to.include('object required for user data. Found [1,2]');
                 })
                 .nodeify(done);
         });

--- a/test/server/middleware/auth/gmeauth.spec.js
+++ b/test/server/middleware/auth/gmeauth.spec.js
@@ -479,7 +479,7 @@ describe('GME authentication', function () {
 
         it('should set to non-object values', async function () {
             const newData = 'someValue';
-            const userData = await auth.setUserDataField(userId, 'test', newData);
+            await auth.setUserDataField(userId, 'test', newData);
             const data = await auth.getUserDataField(userId, 'test');
             assert.equal(data, newData);
         });


### PR DESCRIPTION
The public API for this is still a work-in-progress. A couple outstanding questions/ToDos:
- [x] add the encryption key to the GME config (add a new field to `config.authentication`?)
- [-]  Should I merge `setUserDataField` into `updateUserDataField`? This could get a bit cumbersome if I want to maintain backwards compatibility (or at least something close to it) as the method signature may grow to something like:
```javascript
updateUserDataField(userId, data, overwrite, callback, fields, secure)`
```
Ok, I confess that is a pretty dumb signature but one that is trying not to break any existing code. Something like the following might be more practical:
```javascript
// first one breaks compatibility by adding 'fields' which could result in ambiguous functions
// from before where they could store `true`/`false` under arbitrary nested fields...
updateUserDataField(userId, fields, data, options, callback) 
updateUserDataField(userId, fields, data, options)  // if we drop support for callbacks in favor of promises...
```

Alternatively, we could just add a new method for setting encrypted values and remove it as an option...

Anyway, I am open to thoughts and suggestions!