### PR TITLE
Remove trailing whitespace from key. Fixes #213

### DIFF
--- a/config/validator.js
+++ b/config/validator.js
@@ -148,7 +148,7 @@ function validateConfig(configOrFileName) {
     assertObject('config.authentication.encryption', config.authentication.encryption);
     assertString('config.authentication.encryption.algorithm', config.authentication.encryption.algorithm);
     assertFileExists('config.authentication.encryption.key', config.authentication.encryption.key);
-    key = fs.readFileSync(config.authentication.encryption.key);
+    key = Buffer.from(fs.readFileSync(config.authentication.encryption.key, 'utf8').trim());
     if (key.length !== 32) {
         throwValidationError(
             'config.authentication.encryption.key',

--- a/config/validator.js
+++ b/config/validator.js
@@ -148,13 +148,6 @@ function validateConfig(configOrFileName) {
     assertObject('config.authentication.encryption', config.authentication.encryption);
     assertString('config.authentication.encryption.algorithm', config.authentication.encryption.algorithm);
     assertFileExists('config.authentication.encryption.key', config.authentication.encryption.key);
-    key = Buffer.from(fs.readFileSync(config.authentication.encryption.key, 'utf8').trim());
-    if (key.length !== 32) {
-        throwValidationError(
-            'config.authentication.encryption.key',
-            'must be 32 bytes. Got: ' + key.length + ' bytes'
-        );
-    }
     assertBoolean('config.authentication.allowPasswordReset', config.authentication.allowPasswordReset);
     assertNumber('config.authentication.allowedResetInterval', config.authentication.allowedResetInterval);
     assertNumber('config.authentication.resetTimeout', config.authentication.resetTimeout);

--- a/src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY
+++ b/src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY
@@ -1,1 +1,1 @@
-1234567890asdfghjklpoiuytrewqzxa
+1234567890abcdef1234567890abcdef

--- a/src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY
+++ b/src/server/middleware/auth/EXAMPLE_ENCRYPTION_KEY
@@ -1,1 +1,1 @@
-1234567890asdfghjklpoiuytrewqzx
+1234567890asdfghjklpoiuytrewqzxa

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -27,6 +27,18 @@ var Mongodb = require('mongodb'),
 const crypto = require('crypto');
 const _ = require('underscore');
 const INFERRED_USER_EMAIL = 'em@il';
+function loadEncryptionKey(gmeConfig) {
+    const {algorithm, key} = gmeConfig.authentication.encryption;
+
+    const keyValue = Buffer.from(fs.readFileSync(key, 'utf-8').replace(/\r?\n$/, ''));
+    try {
+        crypto.createCipheriv(algorithm, keyValue, crypto.randomBytes(16));
+    } catch (err) {
+        throw new Error(`Error when loading encryption key: ${err.message}`);
+    }
+
+    return keyValue;
+}
 
 /**
  *
@@ -629,7 +641,7 @@ function GMEAuth(session, gmeConfig) {
     }
 
     const {algorithm} = gmeConfig.authentication.encryption;
-    const key = Buffer.from(fs.readFileSync(gmeConfig.authentication.encryption.key, 'utf8').trim());
+    const key = loadEncryptionKey(gmeConfig);
     function _encrypt(input) {
         const type = typeof input;
         if (type === 'object') {

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -629,7 +629,7 @@ function GMEAuth(session, gmeConfig) {
     }
 
     const {algorithm} = gmeConfig.authentication.encryption;
-    const key = fs.readFileSync(gmeConfig.authentication.encryption.key);
+    const key = Buffer.from(fs.readFileSync(gmeConfig.authentication.encryption.key, 'utf8').trim());
     function _encrypt(input) {
         const type = typeof input;
         if (type === 'object') {


### PR DESCRIPTION
This removes trailing whitespace from encryption key and validates the key on server start.