### PR TITLE
Only decrypt data if encrypted. Fixes #217

### DIFF
--- a/src/server/api/index.js
+++ b/src/server/api/index.js
@@ -381,9 +381,8 @@ function createAPI(app, mountPath, middlewareOpts) {
     router.get(/\/user\/data\/?(.*)/, ensureAuthenticated, function (req, res, next) {
         const userId = getUserId(req);
         const keys = getUserDataKeys(req);
-        const {decrypt = false} = req.query;
 
-        gmeAuth.getUserDataField(userId, keys, decrypt)
+        gmeAuth.getUserDataField(userId, keys)
             .then(function (data) {
                 res.json(data);
             })

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -662,11 +662,14 @@ function GMEAuth(session, gmeConfig) {
     }
 
     function _decrypt(encrypted) {
-        const isEncryptedObject = !(encrypted.iv && encrypted.encryptedData);
+        const isEncryptedData = encrypted.iv && encrypted.encryptedData;
+        const isEncryptedObject = !isEncryptedData && typeof encrypted === 'object';
         if (isEncryptedObject) {
-            return _.mapObject(encrypted, _decryptData);
-        } else {
+            return _.mapObject(encrypted, _decrypt);
+        } else if (isEncryptedData) {
             return _decryptData(encrypted);
+        } else {
+            return encrypted;
         }
     }
 
@@ -739,7 +742,7 @@ function GMEAuth(session, gmeConfig) {
             result = result[key];
         });
 
-        if (decrypt) {
+        if (decrypt && result) {
             result = _decrypt(result);
         }
 

--- a/src/server/middleware/auth/gmeauth.js
+++ b/src/server/middleware/auth/gmeauth.js
@@ -723,7 +723,7 @@ function GMEAuth(session, gmeConfig) {
         return _deleteUserObjectField(userId, fields);
     }
 
-    async function getUserDataField(userId, fields = [], decrypt = false) {
+    async function getUserDataField(userId, fields = []) {
         if (typeof fields === 'string') {
             fields = [fields];
         }
@@ -742,11 +742,7 @@ function GMEAuth(session, gmeConfig) {
             result = result[key];
         });
 
-        if (decrypt && result) {
-            result = _decrypt(result);
-        }
-
-        return result;
+        return _decrypt(result);
     }
 
     /**

--- a/test/server/api/user/index.user.spec.js
+++ b/test/server/api/user/index.user.spec.js
@@ -1738,48 +1738,10 @@ describe('USER REST API', function () {
                     });
             });
 
-            it('should decrypt user data GET /api/v1/user/data/user/password?decrypt=true', async function () {
+            it('should decrypt user data GET /api/v1/user/data/user/password', async function () {
                 const user = 'user_w_nesteddata1';
                 const newData = 'IAmASecret';
                 const keys = ['user', 'password'];
-                await gmeAuth.setUserDataField(user, keys, newData, {encrypt: true});
-                const response = await new Promise((resolve, reject) => 
-                    agent.get(server.getUrl() + '/api/v1/user/data/' + keys.join('/') + '?decrypt=true')
-                        .set('Authorization', 'Basic ' + new Buffer(`${user}:plaintext`).toString('base64'))
-                        .end(function (err, res) {
-                            if (err) {
-                                return reject(err);
-                            }
-                            resolve(res);
-                        })
-                );
-                assert.equal(response.status, 200);
-                assert.equal(response.body, newData);
-            });
-
-            it('should get unencrypted user data GET /api/v1/user/data/user/test?decrypt=true', async function () {
-                const user = 'user_w_nesteddata1';
-                const newData = 'IAmNotASecret';
-                const keys = ['user', 'test'];
-                await gmeAuth.setUserDataField(user, keys, newData);
-                const response = await new Promise((resolve, reject) =>
-                    agent.get(server.getUrl() + '/api/v1/user/data/' + keys.join('/') + '?decrypt=true')
-                        .set('Authorization', 'Basic ' + new Buffer(`${user}:plaintext`).toString('base64'))
-                        .end(function (err, res) {
-                            if (err) {
-                                return reject(err);
-                            }
-                            resolve(res);
-                        })
-                );
-                assert.equal(response.status, 200);
-                assert.equal(response.body, newData);
-            });
-
-            it('should get encrypted user data GET /api/v1/user/data/user/password?decrypt=true', async function () {
-                const user = 'user_w_nesteddata1';
-                const newData = 'IAmASecret';
-                const keys = ['user', 'otherPassword'];
                 await gmeAuth.setUserDataField(user, keys, newData, {encrypt: true});
                 const response = await new Promise((resolve, reject) => 
                     agent.get(server.getUrl() + '/api/v1/user/data/' + keys.join('/'))
@@ -1792,10 +1754,26 @@ describe('USER REST API', function () {
                         })
                 );
                 assert.equal(response.status, 200);
-                assert.equal(typeof response.body, 'object');
-                assert(response.body.iv);
-                assert(response.body.encryptedData);
-                assert.notEqual(response.body, newData);
+                assert.equal(response.body, newData);
+            });
+
+            it('should get unencrypted user data GET /api/v1/user/data/user/test', async function () {
+                const user = 'user_w_nesteddata1';
+                const newData = 'IAmNotASecret';
+                const keys = ['user', 'test'];
+                await gmeAuth.setUserDataField(user, keys, newData);
+                const response = await new Promise((resolve, reject) =>
+                    agent.get(server.getUrl() + '/api/v1/user/data/' + keys.join('/'))
+                        .set('Authorization', 'Basic ' + new Buffer(`${user}:plaintext`).toString('base64'))
+                        .end(function (err, res) {
+                            if (err) {
+                                return reject(err);
+                            }
+                            resolve(res);
+                        })
+                );
+                assert.equal(response.status, 200);
+                assert.equal(response.body, newData);
             });
 
             it('should get user data basic authentication GET /api/v1/user/data', function (done) {

--- a/test/server/api/user/index.user.spec.js
+++ b/test/server/api/user/index.user.spec.js
@@ -1757,6 +1757,25 @@ describe('USER REST API', function () {
                 assert.equal(response.body, newData);
             });
 
+            it('should get unencrypted user data GET /api/v1/user/data/user/test?decrypt=true', async function () {
+                const user = 'user_w_nesteddata1';
+                const newData = 'IAmNotASecret';
+                const keys = ['user', 'test'];
+                await gmeAuth.setUserDataField(user, keys, newData);
+                const response = await new Promise((resolve, reject) =>
+                    agent.get(server.getUrl() + '/api/v1/user/data/' + keys.join('/') + '?decrypt=true')
+                        .set('Authorization', 'Basic ' + new Buffer(`${user}:plaintext`).toString('base64'))
+                        .end(function (err, res) {
+                            if (err) {
+                                return reject(err);
+                            }
+                            resolve(res);
+                        })
+                );
+                assert.equal(response.status, 200);
+                assert.equal(response.body, newData);
+            });
+
             it('should get encrypted user data GET /api/v1/user/data/user/password?decrypt=true', async function () {
                 const user = 'user_w_nesteddata1';
                 const newData = 'IAmASecret';

--- a/test/server/middleware/auth/gmeauth.spec.js
+++ b/test/server/middleware/auth/gmeauth.spec.js
@@ -480,7 +480,7 @@ describe('GME authentication', function () {
         it('should set/get encrypted field value', async function () {
             const newData = {hello: 'world'};
             const userData = await auth.setUserDataField(userId, 'test', newData, {encrypt: true});
-            const data = await auth.getUserDataField(userId, 'test', true);
+            const data = await auth.getUserDataField(userId, 'test');
             assert.deepEqual(data, newData);
             assert.notEqual(userData.test.hello, newData.hello);
         });
@@ -488,9 +488,7 @@ describe('GME authentication', function () {
         it('should set/get encrypted string value', async function () {
             const newData = 'testValue';
             await auth.setUserDataField(userId, 'test', newData, {encrypt: true});
-            const encryptedData = await auth.getUserDataField(userId, 'test');
-            assert.notEqual(encryptedData, newData);
-            const data = await auth.getUserDataField(userId, 'test', true);
+            const data = await auth.getUserDataField(userId, 'test');
             assert.equal(data, newData);
         });
 


### PR DESCRIPTION
I encountered annoying responses from the server during development where it would respond with a 500 status code because the data to be retrieved is not encrypted. Given that this fix is pretty easy to implement, I figured I would open a PR with a possible fix to start a discussion around this.

That said, it isn't obvious that this is necessarily the best approach. It could be argued that:
- the 500 responses are actually good as they make it obvious that the data is not actually encrypted when it is expected to be/should be.
- data should always be decrypted when possible. That is, if the `decrypt` flag can handle unencrypted data, shouldn't it be enabled by default?

@kecso 