### PR TITLE
Blob issue

### DIFF
--- a/src/server/middleware/blob/BlobFSBackend.js
+++ b/src/server/middleware/blob/BlobFSBackend.js
@@ -106,11 +106,14 @@ BlobFSBackend.prototype.putObject = function (readStream, bucket, callback) {
         });
 
         readStream.on('close', function () {
-            self.logger.error('readStream on close');
-            if (writeStreamWasClosed === false) {
-                readStreamWasClosed = true;
-                writeStream.close();
-            }
+            self.logger.info('readStream on close');
+            setTimeout(() => {
+                if (writeStreamWasClosed === false) {
+                    self.logger.info('readStream on close processing');
+                    readStreamWasClosed = true;
+                    writeStream.close();
+                }
+            }, 100);
         });
 
         readStream.on('error', function (err) {

--- a/src/server/middleware/blob/BlobFSBackend.js
+++ b/src/server/middleware/blob/BlobFSBackend.js
@@ -50,10 +50,11 @@ BlobFSBackend.prototype.putObject = function (readStream, bucket, callback) {
         writeStream.on('close', function () {
             writeStreamWasClosed = true;
             self.logger.debug('writeStream on close, was read closed?', readStreamWasClosed);
+            /* TODO: check if there is really a requirement that readstream close should arrive before writestream close
             if (readStreamWasClosed) {
                 callback(new Error('ReadStream was closed while writing file!'));
                 return;
-            }
+            }*/
             // at this point the temporary file have been written out
             // now the file have been written out
             // finalizing hash and moving temporary file..
@@ -106,14 +107,12 @@ BlobFSBackend.prototype.putObject = function (readStream, bucket, callback) {
         });
 
         readStream.on('close', function () {
-            self.logger.info('readStream on close');
-            setTimeout(() => {
-                if (writeStreamWasClosed === false) {
-                    self.logger.info('readStream on close processing');
-                    readStreamWasClosed = true;
-                    writeStream.close();
-                }
-            }, 100);
+            self.logger.debug('readStream on close, rsClosed?', readStreamWasClosed, 'wsClosed?', writeStreamWasClosed);
+            if (writeStreamWasClosed === false) {
+                self.logger.info('readStream on close processing');
+                readStreamWasClosed = true;
+                writeStream.close();
+            }
         });
 
         readStream.on('error', function (err) {

--- a/test/server/middleware/blob/BlobFsBackend.spec.js
+++ b/test/server/middleware/blob/BlobFsBackend.spec.js
@@ -40,7 +40,8 @@ describe('BlobFSBackend.spec', function () {
         });
     });
 
-    it('should return abort error when putFile when passing in fs.createReadStream and destroy', function (done) {
+    // TODO: this only make sense if we except that read sources can be closed accidentally and we should be able to get that...
+    it.skip('should return abort error when putFile when passing in fs.createReadStream and destroy', function (done) {
         var bb = new BlobFSBackend(gmeConfig, logger),
             readStream = fs.createReadStream('./test/server/middleware/blob/BlobFsBackend/content.txt');
 

--- a/test/server/middleware/blob/BlobFsBackend.spec.js
+++ b/test/server/middleware/blob/BlobFsBackend.spec.js
@@ -40,7 +40,8 @@ describe('BlobFSBackend.spec', function () {
         });
     });
 
-    // TODO: this only make sense if we except that read sources can be closed accidentally and we should be able to get that...
+    // TODO: this only make sense 
+    // if we except that read sources can be closed accidentally and we should be able to get that...
     it.skip('should return abort error when putFile when passing in fs.createReadStream and destroy', function (done) {
         var bb = new BlobFSBackend(gmeConfig, logger),
             readStream = fs.createReadStream('./test/server/middleware/blob/BlobFsBackend/content.txt');


### PR DESCRIPTION
Fixes #243.
There are some occurrences where the readstream was closed before the write stream but there was no error and all the content was successfully uploaded.
As we do not expect read source closure without error, we removed the specific error handling in this cases so there will be no error...