### PR TITLE
Fix for inferred user login issues

### DIFF
--- a/src/server/standalone.js
+++ b/src/server/standalone.js
@@ -769,7 +769,11 @@ class StandAloneServer {
             //client contents - js/html/css
             __app.get(/^\/.*\.(css|ico|ttf|woff|woff2|js|cur)$/, Express.static(__clientBaseDir));
 
-            __app.get('/package.json', ensureAuthenticated, Express.static(path.join(__baseDir, '..')));
+            // There is no secret inside the package.json so it is better if it can be downloaded before 
+            // authentication finishes/
+            
+            __app.get('/package.json', Express.static(path.join(__baseDir, '..')));
+
             __app.get(/^\/.*\.(_js|html|gif|png|bmp|svg|json|map)$/, 
                 ensureAuthenticated, Express.static(__clientBaseDir));
 

--- a/test/server/standalone.spec.js
+++ b/test/server/standalone.spec.js
@@ -230,7 +230,6 @@ describe('standalone server', function () {
         requests: [
             // should not allow access without auth
             {code: 200, url: '/', redirectUrl: '/login'},
-            {code: 200, url: '/package.json', redirectUrl: '/login'},
             {code: 200, url: '/file._js', redirectUrl: '/login'},
             {code: 200, url: '/file.html', redirectUrl: '/login'},
             {code: 200, url: '/file.gif', redirectUrl: '/login'},
@@ -247,6 +246,7 @@ describe('standalone server', function () {
             {code: 200, url: '/common/storage/constants.js'},
             {code: 200, url: '/common/blob/BlobClient.js'},
             {code: 200, url: '/gmeConfig.json'},
+            {code: 200, url: '/package.json'},
 
             {code: 401, url: '/api/plugins'},
             {code: 401, url: '/api/decorators'},


### PR DESCRIPTION
Due to some racing conditions it can happen that the 'package.json' is required by the client (in case of inferred user) before the authentication finishes.
Being WebGME free to use and the package.json should not contain any sensitive data, the authentication requirement was removed on the file access.
Fixes #245.