### PR TITLE
Add option to expose the end-point listing all available blob artifacts

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -123,7 +123,7 @@ Modification of arrays is not support, but non-existing config sub-group (object
 
 ##### blob
 - `config.blob.allowListAll = false`
- - If true the end-point `/rest/blob/metadata` will return a listing of all available artifacts.
+ - If true the end-point `/rest/blob/metadata` will return a listing of all available artifacts, see [#308](https://github.com/webgme/webgme-engine/pull/308) for details.
 - `config.blob.compressionLevel = 0`
  - Compression level of DEFLATE (between 0 and 9) to use when serving bundled complex artifacts.
 - `config.blob.type = 'FS'`

--- a/config/README.md
+++ b/config/README.md
@@ -122,6 +122,8 @@ Modification of arrays is not support, but non-existing config sub-group (object
  - Logger settings when running bin scripts.
 
 ##### blob
+- `config.blob.allowListAll = false`
+ - If true the end-point `/rest/blob/metadata` will return a listing of all available artifacts.
 - `config.blob.compressionLevel = 0`
  - Compression level of DEFLATE (between 0 and 9) to use when serving bundled complex artifacts.
 - `config.blob.type = 'FS'`

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -83,6 +83,7 @@ var path = require('path'),
 
         blob: {
             compressionLevel: 0,
+            allowListAll: false,
             type: 'FS', //'FS', 'S3'
             fsDir: './blob-local-storage',
             namespace: '',

--- a/src/server/middleware/blob/BlobServer.js
+++ b/src/server/middleware/blob/BlobServer.js
@@ -64,7 +64,7 @@ function createExpressBlob(options) {
     }); */
 
     __app.get('/metadata', ensureAuthenticated, function (req, res) {
-        if (options.gmeConfig.debug) {
+        if (options.gmeConfig.debug || options.gmeConfig.blob.allowListAll) {
             blobBackend.listAllMetadata(req.query.all, function (err, metadata) {
                 if (err) {
                     logger.error(err);


### PR DESCRIPTION
Note that if this is set to true all blob-artifacts will be visible from `<baseUrl>/rest/blob/metadata` which could be a security issue on public and/or production deployments. 
This end-point is mainly meant to be used for smaller development deployments or to the very least local/internal deployments.