### PR TITLE
Fixes #284 newly introduced Blob in nodejs not compatible with BlobClient

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,11 +18,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
       - name: Use Node.js {{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/setup-python@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16.x]
+        node: [16, 18]
         mongodb-version: [4.4]
         python-version: [3.8]
         redis-version: [6]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Start MongoDB ${{ matrix.mongodb-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,6 +10,7 @@ jobs:
     name: testing
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node: [16, 18]
         mongodb-version: [4.4]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,6 +38,8 @@ jobs:
           redis-version: ${{ matrix.redis-version }}
       - name: Chrome
         uses: browser-actions/setup-chrome@latest
+      - name: node version
+        run: node --version
       - name: NPM install
         run: npm install 
       - name: ESLint Check

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16.x, 18.x]
+        node: [16.x]
         mongodb-version: [4.4]
         python-version: [3.8]
         redis-version: [6]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Use Node.js {{ matrix.node-version }}
+      - name: Use Node.js {{ matrix.node }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://opensource.org/licenses/MIT)
-[![Build Status](https://travis-ci.org/webgme/webgme-engine.svg?branch=master)](https://travis-ci.org/webgme/webgme-engine)
+[![Build status](https://img.shields.io/github/actions/workflow/status/webgme/webgme-engine/ci.yml?branch=master&label=CI&logo=github&style=flat-square)](https://github.com/webgme/webgme-engine/actions/workflows/ci.yml)
 [![Version](https://badge.fury.io/js/webgme-engine.svg)](https://www.npmjs.com/package/webgme-engine)
 [![Downloads](http://img.shields.io/npm/dm/webgme-engine.svg?style=flat)](http://img.shields.io/npm/dm/webgme-engine.svg?style=flat)
 

--- a/src/common/blob/Artifact.js
+++ b/src/common/blob/Artifact.js
@@ -277,8 +277,6 @@ define([
         var deferred = Q.defer();
 
         this.blobClient.putMetadata(this.descriptor, function (err, hash) {
-            /*eslint-disable no-console*/
-            console.log(311);
             if (err) {
                 deferred.reject(err);
             } else {

--- a/src/common/blob/Artifact.js
+++ b/src/common/blob/Artifact.js
@@ -277,6 +277,8 @@ define([
         var deferred = Q.defer();
 
         this.blobClient.putMetadata(this.descriptor, function (err, hash) {
+            /*eslint-disable no-console*/
+            console.log(311);
             if (err) {
                 deferred.reject(err);
             } else {

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -281,6 +281,7 @@ define([
         console.log(3111);
         this.logger.debug('putMetadata', {metadata: metadataDescriptor});
         if (typeof Blob !== 'undefined') {
+            console.log('Blob defined');
             blob = new Blob([JSON.stringify(metadata.serialize(), null, 4)], {type: 'text/plain'});
             contentLength = blob.size;
         } else {

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -1,6 +1,5 @@
 /*globals define, Uint8Array, ArrayBuffer, WebGMEGlobal*/
 /*eslint-env node, browser*/
-
 /**
  * Client module for accessing the blob.
  *
@@ -57,7 +56,7 @@ define([
                 self.logger.debug('File upload of', fName, e.percent, '%');
             };
         }
-
+        /*eslint-disable no-console*/
         this.logger.debug('ctor', {metadata: parameters});
 
         if (parameters) {
@@ -279,6 +278,7 @@ define([
             contentLength,
             req;
         // FIXME: in production mode do not indent the json file.
+        console.log(3111);
         this.logger.debug('putMetadata', {metadata: metadataDescriptor});
         if (typeof Blob !== 'undefined') {
             blob = new Blob([JSON.stringify(metadata.serialize(), null, 4)], {type: 'text/plain'});
@@ -287,27 +287,31 @@ define([
             blob = Buffer.from(JSON.stringify(metadata.serialize(), null, 4), 'utf8');
             contentLength = blob.length;
         }
-
+        console.log(3112);
         req = superagent.post(this.getCreateURL(metadataDescriptor.name, true));
         this._setAuthHeaders(req);
-
+        console.log(3113);
         if (typeof window === 'undefined') {
             req.agent(this.keepaliveAgent);
             req.set('Content-Length', contentLength);
         }
-
+        console.log(3114);
         req.set('Content-Type', 'application/octet-stream')
             .send(blob)
             .end(function (err, res) {
+                console.log(3115);
                 if (err || res.status > 399) {
                     deferred.reject(err || new Error(res.status));
                     return;
                 }
+                console.log(3116);
                 // Uploaded.
                 var response = JSON.parse(res.text);
                 // Get the first one
+                console.log(3117);
                 var hash = Object.keys(response)[0];
                 self.logger.debug('putMetadata - result', hash);
+                console.log(3118);
                 deferred.resolve(hash);
             });
 

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -56,7 +56,7 @@ define([
                 self.logger.debug('File upload of', fName, e.percent, '%');
             };
         }
-        /*eslint-disable no-console*/
+
         this.logger.debug('ctor', {metadata: parameters});
 
         if (parameters) {

--- a/src/common/blob/BlobClient.js
+++ b/src/common/blob/BlobClient.js
@@ -278,41 +278,38 @@ define([
             contentLength,
             req;
         // FIXME: in production mode do not indent the json file.
-        console.log(3111);
         this.logger.debug('putMetadata', {metadata: metadataDescriptor});
-        if (typeof Blob !== 'undefined') {
-            console.log('Blob defined');
+        if (typeof Blob !== 'undefined' && typeof window !== 'undefined') {
+            // This does not work using the "new" Blob class in nodejs - so make sure (for now at least) that
+            // we running under a brower even though Blob is defined.
+            // https://nodejs.org/api/buffer.html#class-blob
             blob = new Blob([JSON.stringify(metadata.serialize(), null, 4)], {type: 'text/plain'});
             contentLength = blob.size;
         } else {
             blob = Buffer.from(JSON.stringify(metadata.serialize(), null, 4), 'utf8');
             contentLength = blob.length;
         }
-        console.log(3112);
+
         req = superagent.post(this.getCreateURL(metadataDescriptor.name, true));
         this._setAuthHeaders(req);
-        console.log(3113);
+
         if (typeof window === 'undefined') {
             req.agent(this.keepaliveAgent);
             req.set('Content-Length', contentLength);
         }
-        console.log(3114);
+
         req.set('Content-Type', 'application/octet-stream')
             .send(blob)
             .end(function (err, res) {
-                console.log(3115);
                 if (err || res.status > 399) {
                     deferred.reject(err || new Error(res.status));
                     return;
                 }
-                console.log(3116);
                 // Uploaded.
                 var response = JSON.parse(res.text);
                 // Get the first one
-                console.log(3117);
                 var hash = Object.keys(response)[0];
                 self.logger.debug('putMetadata - result', hash);
-                console.log(3118);
                 deferred.resolve(hash);
             });
 

--- a/src/server/middleware/blob/BlobServer.js
+++ b/src/server/middleware/blob/BlobServer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /*globals requireJS*/
 /*eslint-env node*/
 
@@ -136,27 +135,22 @@ function createExpressBlob(options) {
     });
 
     __app.post('/createMetadata', ensureAuthenticated, function (req, res) {
-        console.log('s1');
         var data = '';
 
         req.addListener('data', function (chunk) {
             data += chunk;
         });
 
-        console.log('s2');
         req.addListener('end', function () {
             var metadata;
             try {
                 metadata = new BlobMetadata(JSON.parse(data));
-                console.log('s3');
             } catch (e) {
                 res.status(500);
                 res.send(e);
                 return;
             }
-            console.log('s4');
             blobBackend.putMetadata(metadata, function (err, hash) {
-                console.log('s5');
                 if (err) {
                     logger.error(err);
                     res.status(err.statusCode || 500);
@@ -164,7 +158,6 @@ function createExpressBlob(options) {
                 } else {
                     // FIXME: it should be enough to send back the hash only
                     blobBackend.getMetadata(hash, function (err, metadataHash, metadata) {
-                        console.log('s6');
                         if (err) {
                             logger.error(err);
                             res.status(err.statusCode || 500);
@@ -174,7 +167,6 @@ function createExpressBlob(options) {
                             res.setHeader('Content-type', 'application/json');
                             var info = {};
                             info[hash] = metadata;
-                            console.log('s7');
                             res.end(JSON.stringify(info, null, 4));
                         }
                     });

--- a/src/server/middleware/blob/BlobServer.js
+++ b/src/server/middleware/blob/BlobServer.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /*globals requireJS*/
 /*eslint-env node*/
 
@@ -135,23 +136,27 @@ function createExpressBlob(options) {
     });
 
     __app.post('/createMetadata', ensureAuthenticated, function (req, res) {
-
+        console.log('s1');
         var data = '';
 
         req.addListener('data', function (chunk) {
             data += chunk;
         });
 
+        console.log('s2');
         req.addListener('end', function () {
             var metadata;
             try {
                 metadata = new BlobMetadata(JSON.parse(data));
+                console.log('s3');
             } catch (e) {
                 res.status(500);
                 res.send(e);
                 return;
             }
+            console.log('s4');
             blobBackend.putMetadata(metadata, function (err, hash) {
+                console.log('s5');
                 if (err) {
                     logger.error(err);
                     res.status(err.statusCode || 500);
@@ -159,6 +164,7 @@ function createExpressBlob(options) {
                 } else {
                     // FIXME: it should be enough to send back the hash only
                     blobBackend.getMetadata(hash, function (err, metadataHash, metadata) {
+                        console.log('s6');
                         if (err) {
                             logger.error(err);
                             res.status(err.statusCode || 500);
@@ -168,6 +174,7 @@ function createExpressBlob(options) {
                             res.setHeader('Content-type', 'application/json');
                             var info = {};
                             info[hash] = metadata;
+                            console.log('s7');
                             res.end(JSON.stringify(info, null, 4));
                         }
                     });

--- a/test/common/blob/Artifact.spec.js
+++ b/test/common/blob/Artifact.spec.js
@@ -271,7 +271,7 @@ describe('Blob Artifact', function () {
             });
         });
 
-        it('should addObjectHashes', function (done) {
+        it.skip('should addObjectHashes', function (done) {
             var bc = new BlobClient(bcParam),
                 filesToAdd = {
                     'a.txt': 'tttt'

--- a/test/common/blob/Artifact.spec.js
+++ b/test/common/blob/Artifact.spec.js
@@ -1,4 +1,5 @@
 /*eslint-env node, mocha*/
+/*eslint-disable no-console*/
 /**
  * @author pmeijer / https://github.com/pmeijer
  */
@@ -271,36 +272,45 @@ describe('Blob Artifact', function () {
             });
         });
 
-        it.skip('should addObjectHashes', function (done) {
+        it('should addObjectHashes', function (done) {
             var bc = new BlobClient(bcParam),
                 filesToAdd = {
                     'a.txt': 'tttt'
                 },
                 artifact = new Artifact('testartifact', bc);
+
+            console.log(1);
             bc.putFiles(filesToAdd, function (err, objHashes) {
+                console.log(2);
                 if (err) {
                     done(err);
                     return;
                 }
                 artifact.addObjectHashes(objHashes, function (err/*, hashes*/) {
+                    console.log(3);
                     if (err) {
                         done(err);
                         return;
                     }
                     artifact.save(function (err, artHash) {
+                        console.log(4);
                         if (err) {
                             done(err);
                             return;
                         }
                         var url = bc.getViewURL(artHash, 'a.txt');
+                        console.log(5);
                         agent.get(url).end(function (err, res) {
+                            console.log(6);
                             if (err) {
                                 done(err);
                                 return;
                             }
 
                             try {
+                                console.log(7);
                                 should.equal(res.status, 200);
+                                console.log(8);
                                 should.equal(res.text, 'tttt');
                                 done();
                             } catch (err) {

--- a/test/common/blob/Artifact.spec.js
+++ b/test/common/blob/Artifact.spec.js
@@ -1,5 +1,4 @@
 /*eslint-env node, mocha*/
-/*eslint-disable no-console*/
 /**
  * @author pmeijer / https://github.com/pmeijer
  */
@@ -279,39 +278,30 @@ describe('Blob Artifact', function () {
                 },
                 artifact = new Artifact('testartifact', bc);
 
-            console.log(1);
             bc.putFiles(filesToAdd, function (err, objHashes) {
-                console.log(2);
                 if (err) {
                     done(err);
                     return;
                 }
                 artifact.addObjectHashes(objHashes, function (err/*, hashes*/) {
-                    console.log(3);
                     if (err) {
                         done(err);
                         return;
                     }
-                    console.log(31);
                     artifact.save(function (err, artHash) {
-                        console.log(4);
                         if (err) {
                             done(err);
                             return;
                         }
                         var url = bc.getViewURL(artHash, 'a.txt');
-                        console.log(5);
                         agent.get(url).end(function (err, res) {
-                            console.log(6);
                             if (err) {
                                 done(err);
                                 return;
                             }
 
                             try {
-                                console.log(7);
                                 should.equal(res.status, 200);
-                                console.log(8);
                                 should.equal(res.text, 'tttt');
                                 done();
                             } catch (err) {

--- a/test/common/blob/Artifact.spec.js
+++ b/test/common/blob/Artifact.spec.js
@@ -292,6 +292,7 @@ describe('Blob Artifact', function () {
                         done(err);
                         return;
                     }
+                    console.log(31);
                     artifact.save(function (err, artHash) {
                         console.log(4);
                         if (err) {

--- a/test/common/blob/BlobClient.spec.js
+++ b/test/common/blob/BlobClient.spec.js
@@ -439,12 +439,12 @@ describe('BlobClient', function () {
                 artifact = new BlobClient(bcParam).createArtifact('xmlAndJson');
             artifact.addFiles(filesToAdd, function (err/*, hashes*/) {
                 if (err) {
-                    done('Could not add files : err' + err.toString());
+                    done(new Error('Could not add files : err' + err.toString()));
                     return;
                 }
                 artifact.save(function (err, hash) {
                     if (err) {
-                        done('Could not save artifact : err' + err.toString());
+                        done(new Error('Could not save artifact : err' + err.toString()));
                         return;
                     }
                     var agent = superagent.agent();


### PR DESCRIPTION
The executor worker needs to be update with the new BlobClient for all tests to work in v18.

This PR also updates github action to actually use the specified node version and is now using both 16 and 18.