### PR TITLE
Bump superagent from v3 to v10

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20]
+        node: [20, 24]
         mongodb-version: [8]
         python-version: [3.8]
         redis-version: [6]

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "socket.io": "^2.5.0",
         "socket.io-client": "^2.5.0",
         "socket.io-redis": "^5.4.0",
-        "superagent": "^3.8.3",
+        "superagent": "^10.3.0",
         "underscore": "^1.13.6",
         "webgme-ot": "0.0.16",
         "webgme-rust": "0.1.0",
@@ -740,6 +740,18 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -783,6 +795,15 @@
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "license": "MIT"
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3146,6 +3167,16 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diagnostics": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
@@ -4009,12 +4040,6 @@
         "type": "^2.7.2"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
@@ -4303,28 +4328,34 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
+        "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">= 6"
       }
     },
     "node_modules/formidable": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
@@ -9686,76 +9717,35 @@
       }
     },
     "node_modules/superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "license": "MIT",
       "dependencies": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
       },
       "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/superagent/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/superagent/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/superagent/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/superagent/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "node": ">=4.0.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "socket.io": "^2.5.0",
     "socket.io-client": "^2.5.0",
     "socket.io-redis": "^5.4.0",
-    "superagent": "^3.8.3",
+    "superagent": "^10.3.0",
     "underscore": "^1.13.6",
     "webgme-ot": "0.0.16",
     "webgme-rust": "0.1.0",

--- a/test/common/storage/storageclasses/watchers_documents.spec.js
+++ b/test/common/storage/storageclasses/watchers_documents.spec.js
@@ -28,7 +28,7 @@ describe('watchers documents', function () {
 
     before(function (done) {
         gmeConfig.authentication.enable = true;
-        gmeConfig.socketIO.clientOptions.transports = ['websocket'];
+        // gmeConfig.socketIO.clientOptions.transports = ['websocket'];
 
         testFixture.clearDBAndGetGMEAuth(gmeConfig)
             .then(function (gmeAuth_) {
@@ -67,14 +67,15 @@ describe('watchers documents', function () {
                 userTokens.user2 = res[1];
                 userTokens.userNoAccess = res[2];
                 userTokens.userRead = res[3];
-
-                server = WebGME.standaloneServer(gmeConfig);
                 return Q.allDone([
-                    Q.ninvoke(server, 'start'),
                     // Close connections since we don't need these anymore..
                     gmeAuth.unload(),
                     safeStorage.closeDatabase()
                 ]);
+            })
+            .then(function () {
+                server = WebGME.standaloneServer(gmeConfig);
+                return Q.ninvoke(server, 'start');
             })
             .nodeify(done);
     });

--- a/test/plugin/coreplugins/OTAttributeEditing/OTAttributeEditing.spec.js
+++ b/test/plugin/coreplugins/OTAttributeEditing/OTAttributeEditing.spec.js
@@ -24,7 +24,9 @@ describe('OTAttributeEditing Plugin', function () {
         safeStorage;
 
     before(function (done) {
-        gmeConfig.socketIO.clientOptions.transports = ['websocket'];
+        // This fails with newer versions of node (22+),
+        // just let socket-io pick the transport.
+        // gmeConfig.socketIO.clientOptions.transports = ['websocket'];
         wr = new WorkerRequests(logger, gmeConfig);
 
         testFixture.clearDBAndGetGMEAuth(gmeConfig)

--- a/test/server/api/project/index.project.spec.js
+++ b/test/server/api/project/index.project.spec.js
@@ -1189,20 +1189,26 @@ describe('PROJECT REST API', function () {
             it('should getTags for project /projects/:ownerId/:projectId/tags', function (done) {
                 agent.get(server.getUrl() + '/api/projects/' + projectName2APIPath(projectName) + '/tags')
                     .end(function (err, res) {
-                        expect(res.status).equal(200, err);
-                        expect(res.body).to.have.property('tag');
-
-                        done();
+                        try {
+                            expect(res.status).equal(200, err);
+                            expect(res.body).to.have.property('tag');
+                            done();
+                        } catch (e) {
+                            return done(e);
+                        }
                     });
             });
 
             it('should return commit for project /projects/:ownerId/:projectId/tags/:tagId', function (done) {
                 agent.get(server.getUrl() + '/api/projects/' + projectName2APIPath(projectName) + '/tags/tag')
                     .end(function (err, res) {
-                        expect(res.status).equal(200, err);
-                        expect(res.body.type).to.equal('commit');
-
-                        done();
+                        try {
+                            expect(res.status).equal(200, err);
+                            expect(res.body.type).to.equal('commit');
+                            done();
+                        } catch (e) {
+                            return done(e);
+                        }
                     });
             });
 

--- a/test/server/standalone.spec.js
+++ b/test/server/standalone.spec.js
@@ -14,10 +14,7 @@ describe('standalone server', function () {
 
         should = testFixture.should,
         expect = testFixture.expect,
-        superagent = testFixture.superagent,
         Q = testFixture.Q,
-
-        agent = superagent.agent(),
 
         serverBaseUrl,
 
@@ -25,77 +22,25 @@ describe('standalone server', function () {
         i,
         j;
 
-    // describe('[https]', function () {
-    //     var nodeTLSRejectUnauthorized;
+    function buildUrl(path, query) {
+        var url = new URL(path || '/', serverBaseUrl);
 
-    //     before(function () {
-    //         nodeTLSRejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-    //         process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-    //     });
+        if (query) {
+            Object.keys(query).forEach(function (key) {
+                url.searchParams.set(key, query[key]);
+            });
+        }
 
-    //     after(function () {
-    //         process.env.NODE_TLS_REJECT_UNAUTHORIZED = nodeTLSRejectUnauthorized;
-    //     });
+        return url.toString();
+    }
 
-    //     it('should get main page with an https reverse proxy', function (done) {
-    //         var gmeConfig = testFixture.getGmeConfig(),
-    //             httpProxy = require('http-proxy'),
-    //             path = require('path'),
-    //             proxyServerPort = gmeConfig.server.port - 1,
-    //             server,
-    //             proxy;
-
-    //         server = WebGME.standaloneServer(gmeConfig);
-    //         //
-    //         // Create the HTTPS proxy server in front of a HTTP server
-    //         //
-    //         proxy = httpProxy.createServer({
-    //             target: {
-    //                 host: 'localhost',
-    //                 port: gmeConfig.server.port
-    //             },
-    //             ssl: {
-    //                 key: fs.readFileSync(path.join(__dirname, '..', 'certificates', 'sample-key.pem'), 'utf8'),
-    //                 cert: fs.readFileSync(path.join(__dirname, '..', 'certificates', 'sample-cert.pem'), 'utf8')
-    //             }
-    //         });
-
-    //         server.start(function (err) {
-    //             if (err) {
-    //                 done(err);
-    //                 return;
-    //             }
-    //             proxy.listen(proxyServerPort, function (err) {
-    //                 if (err) {
-    //                     done(err);
-    //                     return;
-    //                 }
-
-    //                 agent.get('https://localhost:' + proxyServerPort + '/index.html').end(function (err, res) {
-    //                     var err0;
-    //                     if (err) {
-    //                         done(err);
-    //                         return;
-    //                     }
-
-    //                     try {
-    //                         should.equal(res.status, 200, err);
-    //                         should.equal(/WebGME/.test(res.text), true, 'Index page response must contain WebGME');
-    //                     } catch (e) {
-    //                         err0 = e;
-    //                     }
-
-    //                     server.stop(function (err) {
-    //                         proxy.close(function (err1) {
-    //                             done(err0 || err || err1);
-    //                         });
-    //                     });
-    //                 });
-    //             });
-    //         });
-    //     });
-    // });
-
+    async function fetchGet(path, options) {
+        options = options || {};
+        return fetch(buildUrl(path, options.query), {
+            method: 'GET',
+            redirect: options.redirect || 'follow'
+        });
+    }
 
     scenarios = [{
         type: 'http',
@@ -236,10 +181,6 @@ describe('standalone server', function () {
                     .nodeify(done);
             });
 
-            beforeEach(function () {
-                agent = superagent.agent();
-            });
-
             after(function (done) {
                 setTimeout(() => {
                     server.stop(done);
@@ -249,45 +190,30 @@ describe('standalone server', function () {
             function addTest(requestTest) {
                 var url = requestTest.url || '/',
                     redirectText = requestTest.redirectUrl ? ' redirects to ' + requestTest.redirectUrl : ' ';
-                it('returns ' + requestTest.code + ' for ' + url + redirectText, function (done) {
+                it('returns ' + requestTest.code + ' for ' + url + redirectText, async function () {
                     // TODO: add POST/DELETE etc support
-                    agent.get(serverBaseUrl + url).end(function (err, res) {
-                        if (err && err.message.indexOf('connect ECONNREFUSED') > -1) {
-                            //console.log('Is server running?', server.isRunning());
-                            done(err);
-                            return;
-                        }
+                    var res,
+                        location;
 
-                        try {
-                            should.equal(res.status, requestTest.code, err);
-
-                            if (requestTest.redirectUrl) {
-                                // redirectedagent
-                                should.equal(res.status, 200);
-                                if (res.headers.location) {
-                                    should.equal(res.headers.location, requestTest.redirectUrl);
-                                }
-                                should.not.equal(res.headers.location, url);
-                                logger.debug(res.headers.location, url, requestTest.redirectUrl);
-                                should.equal(res.redirects.length, 1);
-                            } else {
-                                // was not redirected
-                                //should.equal(res.res.url, url); // FIXME: should server response set the url?
-                                if (res.headers.location) {
-                                    should.equal(res.headers.location, url);
-                                }
-                                if (res.res.url) {
-                                    should.equal(res.res.url, url);
-                                }
-
-                                should.equal(res.redirects.length, 0);
-                            }
-
-                            done();
-                        } catch (e) {
-                            done(e);
-                        }
+                    res = await fetchGet(url, {
+                        redirect: 'manual'
                     });
+
+                    if (requestTest.redirectUrl) {
+                        // redirected response (do not follow redirects)
+                        should.equal(res.status, 302);
+                        location = res.headers.get('location');
+                        should.equal(location && location.indexOf(requestTest.redirectUrl) > -1, true);
+                        should.not.equal(location, url);
+                        logger.debug(location, url, requestTest.redirectUrl);
+                    } else {
+                        // was not redirected
+                        should.equal(res.status, requestTest.code);
+                        location = res.headers.get('location');
+                        if (location) {
+                            should.equal(location, url);
+                        }
+                    }
                 });
             }
 
@@ -323,60 +249,55 @@ describe('standalone server', function () {
             server.stop(done);
         });
 
-        it('should return 404 /decorators/DefaultDecorator/DefaultDecorator.js', function (done) {
-            agent.get(serverBaseUrl + '/decorators/DefaultDecorator/DefaultDecorator.js').end(function (err, res) {
-                should.equal(res.status, 404, err);
-                done();
-            });
+        it('should return 404 /decorators/DefaultDecorator/DefaultDecorator.js', async function () {
+            var res = await fetchGet('/decorators/DefaultDecorator/DefaultDecorator.js');
+            should.equal(res.status, 404);
         });
 
-        it('should list svgs at /assets/decoratorSVGList.json', function (done) {
-            agent.get(serverBaseUrl + '/assets/decoratorSVGList.json').end(function (err, res) {
-                expect(res.status).to.equal(200);
-                expect(res.body).to.include.members([
-                    'default.svg',
-                    'extra-svgs/level1.svg',
-                    'extra-svgs/nested/level2.svg',
-                    'extra-svgs/nested/nested/level3.svg'
-                ]);
+        it('should list svgs at /assets/decoratorSVGList.json', async function () {
+            var res = await fetchGet('/assets/decoratorSVGList.json'),
+                body = await res.json();
 
-                expect(Object.keys(res.body).length).to.equal(4);
-                done();
-            });
+            expect(res.status).to.equal(200);
+            expect(body).to.include.members([
+                'default.svg',
+                'extra-svgs/level1.svg',
+                'extra-svgs/nested/level2.svg',
+                'extra-svgs/nested/nested/level3.svg'
+            ]);
+
+            expect(Object.keys(body).length).to.equal(4);
         });
 
-        it('should return svg file if exists /assets/DecoratorSVG/Attribute.svg', function (done) {
-            agent.get(serverBaseUrl + '/assets/DecoratorSVG/default.svg').end(function (err, res) {
-                expect(res.status).to.equal(200);
-                expect(res.body.toString('utf8')).to.contain('</svg>');
-                done();
-            });
+        it('should return svg file if exists /assets/DecoratorSVG/Attribute.svg', async function () {
+            var res = await fetchGet('/assets/DecoratorSVG/default.svg'),
+                body = await res.text();
+
+            expect(res.status).to.equal(200);
+            expect(body).to.contain('</svg>');
         });
 
-        it('should return svg file if exists /assets/DecoratorSVG/extra-svgs/level1.svg', function (done) {
-            agent.get(serverBaseUrl + '/assets/DecoratorSVG/extra-svgs/level1.svg').end(function (err, res) {
-                expect(res.status).to.equal(200);
-                expect(res.body.toString('utf8')).to.contain('</svg>');
-                done();
-            });
+        it('should return svg file if exists /assets/DecoratorSVG/extra-svgs/level1.svg', async function () {
+            var res = await fetchGet('/assets/DecoratorSVG/extra-svgs/level1.svg'),
+                body = await res.text();
+
+            expect(res.status).to.equal(200);
+            expect(body).to.contain('</svg>');
         });
 
         it('should return svg file if exists /assets/DecoratorSVG/extra-svgs/nested/nested/level3.svg',
-            function (done) {
-                agent.get(serverBaseUrl + '/assets/DecoratorSVG/extra-svgs/nested/nested/level3.svg')
-                    .end(function (err, res) {
-                        expect(res.status).to.equal(200);
-                        expect(res.body.toString('utf8')).to.contain('</svg>');
-                        done();
-                    });
+            async function () {
+                var res = await fetchGet('/assets/DecoratorSVG/extra-svgs/nested/nested/level3.svg'),
+                    body = await res.text();
+
+                expect(res.status).to.equal(200);
+                expect(body).to.contain('</svg>');
             }
         );
 
-        it('should return 404 if svg file does not exist /assets/DecoratorSVG/NoSuchSvg.svg', function (done) {
-            agent.get(serverBaseUrl + '/assets/DecoratorSVG/NoSuchSvg.sv').end(function (err, res) {
-                expect(res.status).to.equal(404);
-                done();
-            });
+        it('should return 404 if svg file does not exist /assets/DecoratorSVG/NoSuchSvg.svg', async function () {
+            var res = await fetchGet('/assets/DecoratorSVG/NoSuchSvg.sv');
+            expect(res.status).to.equal(404);
         });
     });
 
@@ -401,22 +322,22 @@ describe('standalone server', function () {
         });
 
         it('should return default svg file if exists and relative path given /assets/DecoratorSVG/default.svg',
-            function (done) {
-                agent.get(serverBaseUrl + '/assets/DecoratorSVG/extra-svgs/level1.svg').end(function (err, res) {
-                    expect(res.status).to.equal(200);
-                    expect(res.body.toString('utf8')).to.contain('</svg>');
-                    done();
-                });
+            async function () {
+                var res = await fetchGet('/assets/DecoratorSVG/extra-svgs/level1.svg'),
+                    body = await res.text();
+
+                expect(res.status).to.equal(200);
+                expect(body).to.contain('</svg>');
             }
         );
 
         it('should return svg file if exists and relative path given /assets/DecoratorSVG/extra-svgs/level1.svg',
-            function (done) {
-                agent.get(serverBaseUrl + '/assets/DecoratorSVG/extra-svgs/level1.svg').end(function (err, res) {
-                    expect(res.status).to.equal(200);
-                    expect(res.body.toString('utf8')).to.contain('</svg>');
-                    done();
-                });
+            async function () {
+                var res = await fetchGet('/assets/DecoratorSVG/extra-svgs/level1.svg'),
+                    body = await res.text();
+
+                expect(res.status).to.equal(200);
+                expect(body).to.contain('</svg>');
             }
         );
     });
@@ -440,36 +361,22 @@ describe('standalone server', function () {
                 server.stop(done);
             });
 
-            it('should redirect to given logOutUrl when no referrer set', function (done) {
-                agent.get(serverBaseUrl + '/logout').end(function (err, res) {
-                    try {
-                        expect(err).to.equal(null);
-                        expect(res.status).to.equal(200);
-                        expect(res.redirects.length).to.equal(1);
-                        expect(res.redirects[0]).to.equal(serverBaseUrl + '/profile/login');
-                        done();
-                    } catch (e) {
-                        done(e);
-                    }
-                });
+            it('should redirect to given logOutUrl when no referrer set', async function () {
+                var res = await fetchGet('/logout', {redirect: 'manual'});
+                expect(res.status).to.equal(302);
+                expect(res.headers.get('location')).to.equal('/profile/login');
             });
 
-            it('should redirect to logOutUrl even when redirectUrl set', function (done) {
-                agent.get(serverBaseUrl + '/logout')
-                    .query({
+            it('should redirect to logOutUrl even when redirectUrl set', async function () {
+                var res = await fetchGet('/logout', {
+                    redirect: 'manual',
+                    query: {
                         redirectUrl: '/gmeConfig.json'
-                    })
-                    .end(function (err, res) {
-                        try {
-                            expect(err).to.equal(null);
-                            expect(res.status).to.equal(200);
-                            expect(res.redirects.length).to.equal(1);
-                            expect(res.redirects[0]).to.equal(serverBaseUrl + '/profile/login');
-                            done();
-                        } catch (e) {
-                            done(e);
-                        }
-                    });
+                    }
+                });
+
+                expect(res.status).to.equal(302);
+                expect(res.headers.get('location')).to.equal('/profile/login');
             });
         });
 
@@ -492,36 +399,22 @@ describe('standalone server', function () {
                 server.stop(done);
             });
 
-            it('should redirect to given logInUrl when no referrer set', function (done) {
-                agent.get(serverBaseUrl + '/logout').end(function (err, res) {
-                    try {
-                        expect(err).to.equal(null);
-                        expect(res.status).to.equal(200);
-                        expect(res.redirects.length).to.equal(1);
-                        expect(res.redirects[0]).to.equal(serverBaseUrl + '/profile/login');
-                        done();
-                    } catch (e) {
-                        done(e);
-                    }
-                });
+            it('should redirect to given logInUrl when no referrer set', async function () {
+                var res = await fetchGet('/logout', {redirect: 'manual'});
+                expect(res.status).to.equal(302);
+                expect(res.headers.get('location')).to.equal('/profile/login');
             });
 
-            it('should redirect to redirectUrl when query set', function (done) {
-                agent.get(serverBaseUrl + '/logout')
-                    .query({
+            it('should redirect to redirectUrl when query set', async function () {
+                var res = await fetchGet('/logout', {
+                    redirect: 'manual',
+                    query: {
                         redirectUrl: '/gmeConfig.json'
-                    })
-                    .end(function (err, res) {
-                        try {
-                            expect(err).to.equal(null);
-                            expect(res.status).to.equal(200);
-                            expect(res.redirects.length).to.equal(1);
-                            expect(res.redirects[0]).to.equal(serverBaseUrl + '/gmeConfig.json');
-                            done();
-                        } catch (e) {
-                            done(e);
-                        }
-                    });
+                    }
+                });
+
+                expect(res.status).to.equal(302);
+                expect(res.headers.get('location')).to.equal('/gmeConfig.json');
             });
         });
 
@@ -544,34 +437,22 @@ describe('standalone server', function () {
                 server.stop(done);
             });
 
-            it('should redirect to given logOutUrl when no referrer set', function (done) {
-                agent.get(serverBaseUrl + '/logout').end(function (err, res) {
-                    try {
-                        expect(err).to.equal(null);
-                        expect(res.status).to.equal(200);
-                        expect(res.redirects[0]).to.equal(logOutUrl);
-                        done();
-                    } catch (e) {
-                        done(e);
-                    }
-                });
+            it('should redirect to given logOutUrl when no referrer set', async function () {
+                var res = await fetchGet('/logout', {redirect: 'manual'});
+                expect(res.status).to.equal(302);
+                expect(res.headers.get('location')).to.equal(logOutUrl);
             });
 
-            it('should redirect to logOutUrl even when redirectUrl set', function (done) {
-                agent.get(serverBaseUrl + '/logout')
-                    .query({
+            it('should redirect to logOutUrl even when redirectUrl set', async function () {
+                var res = await fetchGet('/logout', {
+                    redirect: 'manual',
+                    query: {
                         redirectUrl: '/gmeConfig.json'
-                    })
-                    .end(function (err, res) {
-                        try {
-                            expect(err).to.equal(null);
-                            expect(res.status).to.equal(200);
-                            expect(res.redirects[0]).to.equal(logOutUrl);
-                            done();
-                        } catch (e) {
-                            done(e);
-                        }
-                    });
+                    }
+                });
+
+                expect(res.status).to.equal(302);
+                expect(res.headers.get('location')).to.equal(logOutUrl);
             });
         });
     });

--- a/test/server/webgme.spec.js
+++ b/test/server/webgme.spec.js
@@ -153,7 +153,7 @@ describe('webgme', function () {
             });
     });
 
-    (process.version.startsWith('v20') ? it.skip : it)('should requestWebGMEToken with auth turned on', (done) => {
+    it('should requestWebGMEToken with auth turned on', (done) => {
         var webGME = testFixture.WebGME,
             gmeConfig = testFixture.getGmeConfig(),
             error,
@@ -204,19 +204,6 @@ describe('webgme', function () {
                     .catch(function (err) {
                         try {
                             expect(err.message).to.include('Unauthorized');
-                        } catch (e) {
-                            error = e;
-                        }
-                    });
-            })
-            .then(function () {
-                return webGME.utils.requestWebGMEToken(gmeConfig, 'admin', 'admin', 'http://localhost:9999')
-                    .then(function () {
-                        throw new Error('Should have failed!');
-                    })
-                    .catch(function (err) {
-                        try {
-                            expect(err.message).to.include('ECONNREFUSED');
                         } catch (e) {
                             error = e;
                         }


### PR DESCRIPTION
This is a potential breaking change since superagent is a shared dependency.
No tests had to be modified here after the upgrade.


The new superagent works better with later versions of node, tests now run under v24. And contains security fixes.