### PR TITLE
Pin ajv for webapi-parser via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8965,24 +8965,6 @@
         "ajv": "6.5.2"
       }
     },
-    "node_modules/webapi-parser/node_modules/ajv": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.1"
-      }
-    },
-    "node_modules/webapi-parser/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-      "license": "MIT"
-    },
     "node_modules/webgme-ot": {
       "version": "0.0.16",
       "resolved": "https://registry.npmjs.org/webgme-ot/-/webgme-ot-0.0.16.tgz",

--- a/package.json
+++ b/package.json
@@ -96,5 +96,10 @@
     "msgpack-js": "^0.3.0",
     "pkginfo": "^0.4.1",
     "rimraf": "^6"
+  },
+  "overrides": {
+    "webapi-parser": {
+      "ajv": "6.15.0"
+    }
   }
 }


### PR DESCRIPTION
webapi-parser@0.5.0 bundles ajv@6.5.2; force nested resolution to ajv@6.15.0 so known ajv advisories are addressed without a new webapi-parser release.